### PR TITLE
Russian translation for moonlight-tv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(USE_SHARED_MBEDTLS_LIBRARY "Build mbed TLS shared library." ON)
 option(BUILD_EXAMPLES "" OFF)
 option(BUILD_TESTS "" ON)
 
-set(I18N_LOCALES "cs" "de" "fr" "it" "nl" "pl" "pt-BR" "ro" "ja" "zh-CN")
+set(I18N_LOCALES "cs" "de" "fr" "it" "nl" "pl" "pt-BR" "ro" "ru" "ja" "zh-CN")
 list(LENGTH I18N_LOCALES I18N_LOCALES_LEN)
 
 set(FEATURE_FORCE_FULLSCREEN OFF)

--- a/i18n/ru/messages.po
+++ b/i18n/ru/messages.po
@@ -503,3 +503,19 @@ msgstr "Открыть moonlight-stream Wiki"
 #: app/app_sdl.c:155
 msgid "Quit Moonlight?"
 msgstr "Выйти из Moonlight?"
+
+#: app/ui/streaming/hints.c:8
+msgid "Long press BACK (or press EXIT for traditional TV remote) while streaming, to open status overlay."
+msgstr "Зажмите BACK (или нажмите EXIT для обычного пульта) во время трансляции, чтобы открыть оверлей"
+
+#: app/ui/streaming/hints.c:9
+msgid "Frequent lagging on 5GHz Wi-Fi? Try changing to another channel, check Help for details."
+msgstr "Частые тормоза на 5Ghz Wi-Fi? Попробуйте сменить канал, загляните в раздел Помощь для подробностей."
+
+#: app/ui/streaming/hints.c:10
+msgid "Xbox One/Series controller can't be directly connected via cable or official adapter."
+msgstr "Подключение геймпада от Xbox One/Series кабелем напрямую или через официальный адаптер не поддерживается."
+
+#: app/ui/streaming/hints.c:11
+msgid "If you have ultra-wide monitor, you may need to change its resolution to fit 16:9 for streaming."
+msgstr "Если у Вас ультраширокий монитор, Вам придётся поменять разрешение формата 16:9 для трансляции."

--- a/i18n/ru/messages.po
+++ b/i18n/ru/messages.po
@@ -1,0 +1,505 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: moonlight-tv\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-12 19:29+0900\n"
+"PO-Revision-Date: 2023-01-05 23:46+0300\n"
+"Last-Translator: Niko2040 <niko2040@4e.by>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: app/main.c:67
+msgid "[Localized Language]"
+msgstr "Русский"
+
+#: app/stream/module/audio.c:53
+msgid "Stereo"
+msgstr "Стерео"
+
+#: app/stream/module/audio.c:54
+msgid "5.1 Surround"
+msgstr "Объёмный звук 5.1"
+
+#: app/stream/module/audio.c:55
+msgid "7.1 Surround"
+msgstr "Объёмный звук 7.1"
+
+#: app/stream/session/connection.c:32
+msgid "Unstable connection."
+msgstr "Нестабильное соединение."
+
+#. Use list button for normal container
+#: app/ui/launcher/launcher.view.c:103
+msgid "Add computer"
+msgstr "Добавить компьютер"
+
+#: app/ui/launcher/launcher.view.c:109 app/ui/help/help.dialog.c:15
+msgid "Help"
+msgstr "Помощь"
+
+#: app/ui/launcher/launcher.view.c:115 app/ui/settings/settings.view.c:30
+msgid "Settings"
+msgstr "Настройки"
+
+#: app/ui/launcher/launcher.view.c:121
+#: app/ui/settings/settings.controller.c:411
+msgid "Quit"
+msgstr "Выход"
+
+#: app/ui/launcher/launcher.controller.c:442
+#: app/ui/launcher/apps.controller.c:597 app/ui/launcher/apps.controller.c:698
+#: app/ui/launcher/add.dialog.c:54 app/ui/launcher/pair.dialog.c:54
+#: app/ui/launcher/server.context_menu.c:118
+#: app/ui/streaming/streaming.controller.c:282 app/app_sdl.c:154
+msgid "OK"
+msgstr "ОК"
+
+#: app/ui/launcher/launcher.controller.c:443
+msgid "Decoder not working"
+msgstr "Декодер не работает"
+
+#: app/ui/launcher/launcher.controller.c:448
+#, c-format
+msgid ""
+"Unable to initialize decoder %s. Please try other decoders.\n"
+"Error detail: %s"
+msgstr ""
+"Невозможно инициализировать декодер %s. Пожалуйста, попробуйте другие декодеры.\n"
+"Подробности ошибки: %s"
+
+#: app/ui/launcher/launcher.controller.c:453
+#, c-format
+msgid "Unable to initialize decoder %s. Please try other decoders."
+msgstr "Невозможно инициализировать декодер %s. Пожалуйста, попробуйте другие декодеры."
+
+#: app/ui/launcher/apps.controller.c:130
+msgid "Wake"
+msgstr "Разбудить"
+
+#: app/ui/launcher/apps.controller.c:130 app/ui/launcher/apps.controller.c:132
+msgid "Retry"
+msgstr "Повторить"
+
+#: app/ui/launcher/apps.controller.c:134
+msgid "Pair"
+msgstr "Подключить"
+
+#: app/ui/launcher/apps.controller.c:368
+msgid "Failed to load apps"
+msgstr "Ошибка загрузки приложений"
+
+#: app/ui/launcher/apps.controller.c:370 app/ui/launcher/apps.controller.c:417
+msgid ""
+"Press \"Retry\" to load again.\n"
+"\n"
+"Restart your computer if error persists."
+msgstr ""
+"Нажмите \"Повторить\" чтобы попытаться загрузить снова.\n"
+"\n"
+"Перезагрузите компьютер, если проблема не устранена."
+
+#: app/ui/launcher/apps.controller.c:399
+msgid "Not paired"
+msgstr "Не сопряжён"
+
+#: app/ui/launcher/apps.controller.c:401
+msgid "Press \"Pair\", and input PIN code on your computer to pair."
+msgstr "Нажмите \"Подключить\" и введите PIN-код на Вашем компьютере для сопряжения."
+
+#: app/ui/launcher/apps.controller.c:415
+msgid "Host error"
+msgstr "Ошибка сервера"
+
+#: app/ui/launcher/apps.controller.c:433
+msgid "Offline"
+msgstr "Не в сети"
+
+#: app/ui/launcher/apps.controller.c:435
+msgid ""
+"Press \"Wake\" to send Wake-on-LAN packet to turn the computer on if it "
+"supports this feature, press \"Retry\" to connect again.\n"
+"\n"
+"Try restart your computer if these doesn't work."
+msgstr ""
+"Нажмите \"Разбудить\" чтобы отправить Wake-on-LAN пакет для включения компьютера "
+"если он поддерживает эту функцию, нажмите \"Повторить\" для повторного подключения.\n"
+"\n"
+"Попробуйте перезагрузить компьютер, если это не работает."
+
+#: app/ui/launcher/apps.controller.c:540
+msgid "Quitting game..."
+msgstr "Выходим из игры..."
+
+#: app/ui/launcher/apps.controller.c:598
+msgid "Unable to quit game"
+msgstr "Невозможно выйти из игры"
+
+#: app/ui/launcher/apps.controller.c:599
+msgid "Please make sure you are quitting with the same client."
+msgstr "Пожалуйста, убедитесь, что вы выходите с тем же клиентом."
+
+#: app/ui/launcher/apps.controller.c:648
+msgid "Resume streaming"
+msgstr "Возобновить трансляцию"
+
+#: app/ui/launcher/apps.controller.c:649
+msgid "Start streaming"
+msgstr "Начать трансляцию"
+
+#: app/ui/launcher/apps.controller.c:655
+msgid "Stop streaming"
+msgstr "Остановить трансляцию"
+
+#: app/ui/launcher/apps.controller.c:659
+msgid "Unstar"
+msgstr "Из закладок"
+
+#: app/ui/launcher/apps.controller.c:659
+msgid "Star"
+msgstr "В закладки"
+
+#: app/ui/launcher/apps.controller.c:663
+#: app/ui/launcher/server.context_menu.c:70
+msgid "Info"
+msgstr "Информация"
+
+#: app/ui/launcher/apps.controller.c:667 app/ui/launcher/add.dialog.c:54
+#: app/ui/launcher/server.context_menu.c:80 app/app_sdl.c:154
+msgid "Cancel"
+msgstr "Отмена"
+
+#: app/ui/launcher/add.dialog.c:69
+msgid "IP address"
+msgstr "IP адрес"
+
+#: app/ui/launcher/add.dialog.c:73
+msgid "IPv4 address only"
+msgstr "Только IPv4 адрес"
+
+#: app/ui/launcher/add.dialog.c:92
+msgid "Failed to add computer."
+msgstr "Ошибка добавления компьютера."
+
+#: app/ui/launcher/pair.dialog.c:55
+msgid "Pairing"
+msgstr "Сопряжение"
+
+#: app/ui/launcher/pair.dialog.c:72
+msgid "Enter PIN code on your computer."
+msgstr "Введите PIN-код на Вашем компьютере."
+
+#: app/ui/launcher/server.context_menu.c:75
+msgid "Forget"
+msgstr "Забыть"
+
+#: app/ui/launcher/server.context_menu.c:121
+#, c-format
+msgid ""
+"IP address: %s\n"
+"GPU: %s\n"
+"Supports 4K: %s\n"
+"Supports HDR: %s\n"
+"GeForce Experience: %s"
+msgstr ""
+"IP адрес: %s\n"
+"GPU: %s\n"
+"Поддерживает 4K: %s\n"
+"Поддерживает HDR: %s\n"
+"GeForce Experience: %s"
+
+#: app/ui/streaming/streaming.view.c:25
+#, c-format
+msgid "Hint: %s"
+msgstr "Подсказка: %s"
+
+#: app/ui/streaming/streaming.view.c:50
+msgid "Soft keyboard"
+msgstr "Виртуальная клавиатура"
+
+#: app/ui/streaming/streaming.view.c:58
+msgid "Virtual Mouse"
+msgstr "Виртуальная мышь"
+
+#: app/ui/streaming/streaming.view.c:66
+msgid "Disconnect"
+msgstr "Отключиться"
+
+#: app/ui/streaming/streaming.view.c:74
+msgid "Quit game"
+msgstr "Выйти из игры"
+
+#: app/ui/streaming/streaming.view.c:89
+msgid "Performance"
+msgstr "Производительность"
+
+#: app/ui/streaming/streaming.controller.c:139
+msgid "Connecting..."
+msgstr "Подключение..."
+
+#: app/ui/streaming/streaming.controller.c:159
+msgid "Disconnecting..."
+msgstr "Отключение..."
+
+#: app/ui/streaming/streaming.controller.c:283
+msgid "Failed to start streaming"
+msgstr "Ошибка запуска трансляции"
+
+#: app/ui/settings/settings.controller.c:20
+msgid "Basic Settings"
+msgstr "Основные настройки"
+
+#: app/ui/settings/settings.controller.c:21
+msgid "Host Settings"
+msgstr "Настройки сервера"
+
+#: app/ui/settings/settings.controller.c:22
+msgid "Input Settings"
+msgstr "Настройки ввода"
+
+#: app/ui/settings/settings.controller.c:23
+msgid "Decoder Settings"
+msgstr "Настройки декодера"
+
+#: app/ui/settings/settings.controller.c:24
+msgid "About"
+msgstr "О программе"
+
+#: app/ui/settings/settings.controller.c:411
+msgid "Later"
+msgstr "Позже"
+
+#: app/ui/settings/settings.controller.c:412
+msgid "Some settings require a restart to take effect."
+msgstr "Некоторые настройки требуют перезапуска для применения."
+
+#: app/ui/settings/panes/basic.pane.c:89
+msgid "Resolution and FPS"
+msgstr "Разрешение и FPS"
+
+#: app/ui/settings/panes/basic.pane.c:125
+msgid "Video bitrate"
+msgstr "Битрейт видео"
+
+#: app/ui/settings/panes/basic.pane.c:142
+msgid "Fullscreen UI"
+msgstr "Полноэкранный UI"
+
+#: app/ui/settings/panes/basic.pane.c:149
+#: app/ui/settings/panes/basic.pane.c:150
+msgid "Language"
+msgstr "Язык"
+
+#: app/ui/settings/panes/basic.pane.c:180
+msgid ""
+"Your computer may not perform well when using this resolution and framerate."
+msgstr ""
+"Ваш компьютер может плохо работать с выбранными разрешением и частотой кадров."
+
+#: app/ui/settings/panes/basic.pane.c:194
+#, c-format
+msgid "Video bitrate - %d kbps"
+msgstr "Битрейт видео - %d кбит/с"
+
+#: app/ui/settings/panes/basic.pane.c:200
+msgid "Higher bitrate may cause performance issue, try with caution."
+msgstr "Более высокий битрейт может вызывать проблемы с производительностью."
+
+#: app/ui/settings/panes/host.pane.c:26
+msgid "Optimize game settings for streaming"
+msgstr "Оптимизировать настройки игры для трансляции"
+
+#: app/ui/settings/panes/host.pane.c:27
+msgid ""
+"Change in-game settings to optimize for streaming. Resolution will be "
+"limited to 720p, 1080p or 4K. Framerate will be also limited to 30/60 FPS."
+msgstr ""
+"Изменить настройки игры для оптимизации под трансляцию. Разрешение будет "
+"ограничено до 720p, 1080p или 4K. Частота кадров тоже будет ограничена до 30/60 FPS."
+
+#: app/ui/settings/panes/host.pane.c:30
+msgid "Mute computer while streaming"
+msgstr "Приглушить компьютер во время трансляции"
+
+#: app/ui/settings/panes/input.pane.c:39
+msgid "View-only mode"
+msgstr "Режим просмотра"
+
+#: app/ui/settings/panes/input.pane.c:40
+msgid "Don't send mouse, keyboard or gamepad input to host computer."
+msgstr "Не отправлять ввод мышки, клавиатуры или геймпада на компьютер."
+
+#: app/ui/settings/panes/input.pane.c:42
+msgid "Mouse"
+msgstr "Мышь"
+
+#: app/ui/settings/panes/input.pane.c:45
+msgid "Use mouse hardware"
+msgstr "Использовать аппаратную мышь"
+
+#: app/ui/settings/panes/input.pane.c:48
+msgid ""
+"Use plugged mouse device only when streaming. This will have better "
+"performance, but absolute mouse mode will not be enabled."
+msgstr ""
+"Использовать подключённую мышь только во время трансляции. Это даст лучшую "
+"производительность, но абсолютный режим мыши станет недоступен."
+
+#: app/ui/settings/panes/input.pane.c:53
+msgid "Absolute mouse mode"
+msgstr "Абсолютный режим мыши"
+
+#: app/ui/settings/panes/input.pane.c:55 app/ui/settings/panes/input.pane.c:85
+msgid ""
+"Better for remote desktop. For some games, mouse will not work properly."
+msgstr ""
+"Лучше для удалённого рабочего стола. В некоторых играх мышь может некорректно работать."
+
+#: app/ui/settings/panes/input.pane.c:58
+msgid "Gamepad"
+msgstr "Геймпад"
+
+#: app/ui/settings/panes/input.pane.c:60
+msgid "Virtual mouse"
+msgstr "Виртуальная мышь"
+
+#: app/ui/settings/panes/input.pane.c:61
+msgid ""
+"Press LB + RT to move mouse cursor with sticks. LT/RT for left/right mouse "
+"buttons."
+msgstr ""
+"Нажмите LB + RT чтобы управлять курсором стиками. LT/RT для левой/правой кнопки "
+"мыши."
+
+#: app/ui/settings/panes/input.pane.c:64
+msgid "Swap ABXY buttons"
+msgstr "Поменять местами ABXY кнопки"
+
+#: app/ui/settings/panes/input.pane.c:65
+msgid ""
+"Swap A/B and X/Y gamepad buttons. Useful when you prefer Nintendo-like "
+"layouts."
+msgstr ""
+"Поменять местами A/B и X/Y кнопки. Полезно, если вы предпочитаете раскладку "
+"Nintendo."
+
+#: app/ui/settings/panes/input.pane.c:81
+msgid "Absolute mouse mode can't be used when \"Use mouse hardware\" enabled."
+msgstr "Абсолютный режим мыши не может быть использован с включённым \"Использовать аппаратную мышь\"."
+
+#: app/ui/settings/panes/decoder.pane.c:50
+#: app/ui/settings/panes/decoder.pane.c:69
+msgid "Automatic"
+msgstr "Автоматически"
+
+#: app/ui/settings/panes/decoder.pane.c:108
+#: app/ui/settings/panes/about.pane.c:76
+msgid "Video decoder"
+msgstr "Видео декодер"
+
+#: app/ui/settings/panes/decoder.pane.c:109
+#, c-format
+msgid "Video decoder - using %s"
+msgstr "Видео декодер - используется %s"
+
+#: app/ui/settings/panes/decoder.pane.c:115
+#: app/ui/settings/panes/about.pane.c:79
+msgid "Audio backend"
+msgstr "Бэкэнд аудио"
+
+#: app/ui/settings/panes/decoder.pane.c:116
+msgid "Decoder provided"
+msgstr ""
+
+#: app/ui/settings/panes/decoder.pane.c:118
+#, c-format
+msgid "Audio backend - using %s"
+msgstr "Бэкэнд аудио - используется %s"
+
+#: app/ui/settings/panes/decoder.pane.c:125
+msgid "Prefer H265 codec"
+msgstr "Предпочитать кодек H265"
+
+#: app/ui/settings/panes/decoder.pane.c:131
+#, c-format
+msgid "%s decoder doesn't support H265 codec."
+msgstr "%s декодер не поддерживает кодек H265"
+
+#: app/ui/settings/panes/decoder.pane.c:135
+msgid "H265 usually has clearer graphics, and is required for using HDR."
+msgstr "У H265 обычно более чёткая графика, и он требуется для HDR."
+
+#: app/ui/settings/panes/decoder.pane.c:139
+msgid "HDR (experimental)"
+msgstr "HDR (экспериментально)"
+
+#: app/ui/settings/panes/decoder.pane.c:144
+#, c-format
+msgid "%s decoder doesn't support HDR."
+msgstr "%s декодер не поддерживает HDR."
+
+#: app/ui/settings/panes/decoder.pane.c:148
+#: app/ui/settings/panes/decoder.pane.c:189
+msgid "H265 is required to use HDR."
+msgstr "H265 требуется для использования HDR."
+
+#: app/ui/settings/panes/decoder.pane.c:151
+#: app/ui/settings/panes/decoder.pane.c:192
+msgid ""
+"HDR is only supported on certain games and when connecting to supported "
+"monitor."
+msgstr ""
+"HDR поддеживается только несколькими играми и только если подключен "
+"поддерживающий HDR монитор."
+
+#: app/ui/settings/panes/decoder.pane.c:154
+msgid "Learn more about HDR feature."
+msgstr "Узнать больше о HDR"
+
+#: app/ui/settings/panes/decoder.pane.c:160
+msgid "Sound Channels (Experimental)"
+msgstr "Звуковые каналы (Экспериментально)"
+
+#: app/ui/settings/panes/about.pane.c:75
+msgid "Version"
+msgstr "Версия"
+
+#: app/ui/settings/panes/about.pane.c:83
+msgid "webOS version"
+msgstr "Версия webOS"
+
+#: app/ui/settings/panes/about.pane.c:86
+msgid "Firmware version"
+msgstr "Версия прошивки"
+
+#: app/ui/settings/panes/about.pane.c:92
+msgid "Screen resolution"
+msgstr "Разрешение экрана"
+
+#: app/ui/settings/panes/about.pane.c:97
+msgid "Refresh rate"
+msgstr "Частота обновления"
+
+#: app/ui/help/help.dialog.c:37
+msgid "Gamepad hotkeys"
+msgstr "Горячие клавиши геймпада"
+
+#: app/ui/help/help.dialog.c:39
+msgid "Remote controller keys"
+msgstr "Кнопки пульта дистанционного управления"
+
+#: app/ui/help/help.dialog.c:42
+msgid "Open moonlight-tv Wiki"
+msgstr "Открыть moonlight-tv Wiki"
+
+#: app/ui/help/help.dialog.c:44
+msgid "Open moonlight-stream Wiki"
+msgstr "Открыть moonlight-stream Wiki"
+
+#: app/app_sdl.c:155
+msgid "Quit Moonlight?"
+msgstr "Выйти из Moonlight?"


### PR DESCRIPTION
I noticed a problem while creating the translation: on webos "Museo Sans" font doesn't have the necessary glyphs. The same problem appears not only in Russian, but also in Japanese (You can see dots instead of characters in the list of languages ​​in the settings). With default sans-serif all characters are rendered ok. For some reason Chinese (zh-CN locale) is missing in the language selection list.