### PR TITLE
Request Surround Sound Params

### DIFF
--- a/core/libgamestream/libgamestream/client.h
+++ b/core/libgamestream/libgamestream/client.h
@@ -62,7 +62,7 @@ void gs_set_timeout(GS_CLIENT hnd, int timeout_secs);
 int gs_get_status(GS_CLIENT hnd, PSERVER_DATA server, const char *address, uint16_t port, bool unsupported);
 
 int gs_start_app(GS_CLIENT hnd, PSERVER_DATA server, PSTREAM_CONFIGURATION config, int appId, bool is_gfe, bool sops,
-                 bool localaudio, int gamepad_mask);
+                 bool localaudio, int gamepad_mask, const char *surround_params);
 
 int gs_applist(GS_CLIENT hnd, const SERVER_DATA *server, PAPP_LIST *app_list);
 

--- a/core/libgamestream/src/client.c
+++ b/core/libgamestream/src/client.c
@@ -481,7 +481,7 @@ int gs_applist(GS_CLIENT hnd, const SERVER_DATA *server, PAPP_LIST *list) {
 }
 
 int gs_start_app(GS_CLIENT hnd, PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, bool is_gfe, bool sops,
-                 bool localaudio, int gamepad_mask) {
+                 bool localaudio, int gamepad_mask, const char* surround_params) {
     int ret = GS_OK;
     char *result = NULL;
     HTTP_DATA *data = NULL;
@@ -553,6 +553,9 @@ int gs_start_app(GS_CLIENT hnd, PSERVER_DATA server, STREAM_CONFIGURATION *confi
     append_param(url, sizeof(url), "rikey", "%s", rikey_hex);
     append_param(url, sizeof(url), "rikeyid", "%d", rikeyid);
     append_param(url, sizeof(url), "surroundAudioInfo", "%d", surround_info);
+    if (surround_params) {
+        append_param(url, sizeof(url), "surroundParams", surround_params);
+    }
     if (!resume || !is_gfe) {
         if (config->supportedVideoFormats & VIDEO_FORMAT_MASK_10BIT) {
             append_param(url, sizeof(url), "hdrMode", "1");

--- a/src/app/stream/session_worker.c
+++ b/src/app/stream/session_worker.c
@@ -30,8 +30,15 @@ int session_worker(session_t *session) {
     commons_log_info("Session", "Launch app %d...", appId);
     GS_CLIENT client = app_gs_client_new(app);
     gs_set_timeout(client, 30);
+    const char *surround_params = NULL;
+#if TARGET_WEBOS
+    if (session->config.stream.audioConfiguration == AUDIO_CONFIGURATION_51_SURROUND) {
+        // 6 channels, 4 streams, 2 coupled streams, FL, FR, SL, SR, FC, LFE
+        surround_params = "642014523";
+    }
+#endif
     int ret = gs_start_app(client, server, &session->config.stream, appId, server->isGfe, session->config.sops,
-                           session->config.local_audio, app_input_gamepads_mask(&app->input));
+                           session->config.local_audio, app_input_gamepads_mask(&app->input), surround_params);
     if (ret != GS_OK) {
         session_set_state(session, STREAMING_ERROR);
         const char *gs_error = NULL;


### PR DESCRIPTION
This feature needs to be used with https://github.com/LizardByte/Sunshine/pull/2424 . After requesting proper OPUS encoding params, webOS 5+ can play surround sound with it.