### PR TITLE
Add missing translatable strings

### DIFF
--- a/src/app/ui/help/help.dialog.c
+++ b/src/app/ui/help/help.dialog.c
@@ -33,12 +33,12 @@ lv_obj_t *help_dialog_create() {
     lv_obj_set_style_pad_all(list, 0, 0);
 
 
-    lv_list_add_text(list, "Input");
+    lv_list_add_text(list, locstr("Input"));
     add_url_button(list, locstr("Gamepad hotkeys"),
                    "https://github.com/mariotaku/moonlight-tv/wiki/Input-Shortcuts#gamepad");
     add_url_button(list, locstr("Remote controller keys"),
                    "https://github.com/mariotaku/moonlight-tv/wiki/Input-Shortcuts#webos-remote-controller");
-    lv_list_add_text(list, "More help");
+    lv_list_add_text(list, locstr("More help"));
     add_url_button(list, locstr("Open moonlight-tv Wiki"),
                    "https://github.com/mariotaku/moonlight-tv/wiki");
     add_url_button(list, locstr("Open moonlight-stream Wiki"),

--- a/src/app/ui/settings/panes/audio.pane.c
+++ b/src/app/ui/settings/panes/audio.pane.c
@@ -107,7 +107,7 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_t *conflict_hint = pref_desc_label(view, NULL, false);
     controller->conflict_hint = conflict_hint;
 
-    pref_header(view, "Audio Settings");
+    pref_header(view, locstr("Audio Settings"));
 
     pref_title_label(view, locstr("Sound Channels (Experimental)"));
 

--- a/src/app/ui/settings/panes/basic.pane.c
+++ b/src/app/ui/settings/panes/basic.pane.c
@@ -157,7 +157,7 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
         lv_obj_add_event_cb(checkbox, on_fullscreen_updated, LV_EVENT_VALUE_CHANGED, pane);
     } else {
         lv_obj_add_state(checkbox, LV_STATE_DISABLED);
-        pref_desc_label(view, "Can't use windowed UI for this decoder", false);
+        pref_desc_label(view, locstr("Can't use windowed UI for this decoder"), false);
     }
 #endif
 

--- a/src/app/ui/settings/panes/video.pane.c
+++ b/src/app/ui/settings/panes/video.pane.c
@@ -90,7 +90,7 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_t *conflict_hint = pref_desc_label(view, NULL, false);
     controller->conflict_hint = conflict_hint;
 
-    pref_header(view, "Video Settings");
+    pref_header(view, locstr("Video Settings"));
 
     lv_obj_t *hevc_checkbox = pref_checkbox(view, locstr("Use H265 when possible"), &app_configuration->hevc, false);
     lv_obj_t *hevc_hint = pref_desc_label(view, NULL, false);


### PR DESCRIPTION
This pull request marks some strings used in the user interface as translatable, so they can be translated for the user's language. Currently those will always appear in English, no matter the chosen language.

I haven't updated `i18n/messages.pot` for now, as I don't know if it's done automatically. Let me know if I should add the new strings manually.