### PR TITLE
Add support for 3200x1800 resolution option in streaming quality settings

### DIFF
--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -167,6 +167,7 @@ int settings_optimal_bitrate(const SS4S_VideoCapabilities *capabilities, int w, 
         case RES_1440P:
             kbps = 20000;
             break;
+        case RES_1800P:
         case RES_4K:
             kbps = 25000;
             break;

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -76,6 +76,7 @@ extern const size_t audio_config_len;
 #define RES_720P RES_MERGE(1280, 720)
 #define RES_1080P RES_MERGE(1920, 1080)
 #define RES_1440P RES_MERGE(2560, 1440)
+#define RES_1800P RES_MERGE(3200, 1800)
 #define RES_4K RES_MERGE(3840, 2160)
 
 void settings_initialize(app_settings_t *config, char *conf_dir);

--- a/src/app/ui/settings/panes/basic.pane.c
+++ b/src/app/ui/settings/panes/basic.pane.c
@@ -49,6 +49,7 @@ static const pref_dropdown_int_pair_entry_t supported_resolutions[] = {
         {"1280 * 720",  1280, 720, true},
         {"1920 * 1080", 1920, 1080},
         {"2560 * 1440", 2560, 1440},
+        {"3200 * 1800", 3200, 1800},
         {"3840 * 2160", 3840, 2160},
 //        {"Automatic", 0,    0, true},
 };


### PR DESCRIPTION
**Description:**  
This pull request adds support for the 3200x1800 resolution option in the streaming quality settings.

#### Changes:  
- Added 3200x1800 resolution to the available resolutions list.

#### Testing:
- Verified that the resolution appears in the settings menu.
- Successfully streamed at 3200x1800 on an LG C4 TV without issues.

Please let me know if any adjustments are needed. Thank you for reviewing!