### PR TITLE
fix(apps): look up controller by uuid in async pcmanager callbacks

### DIFF
--- a/src/app/ui/launcher/apps.controller.c
+++ b/src/app/ui/launcher/apps.controller.c
@@ -256,7 +256,7 @@ static void on_view_created(lv_fragment_t *self, lv_obj_t *view) {
 
     const SERVER_STATE *state = pcmanager_state(pcmanager, &controller->uuid);
     if (state != NULL && state->code != SERVER_STATE_QUERYING) {
-        pcmanager_request_update(pcmanager, &controller->uuid, host_info_cb, controller);
+        pcmanager_request_update(pcmanager, &controller->uuid, host_info_cb, NULL);
         if (state->code == SERVER_STATE_AVAILABLE) {
             apploader_load(controller->apploader);
         }
@@ -342,21 +342,25 @@ static void on_host_removed(const uuidstr_t *uuid, void *userdata) {
 }
 
 static void host_info_cb(int result, const char *error, const uuidstr_t *uuid, void *userdata) {
-    apps_fragment_t *controller = (apps_fragment_t *) userdata;
-    if (controller != current_instance) { return; }
+    LV_UNUSED(userdata);
+    apps_fragment_t *controller = current_instance;
+    if (controller == NULL) { return; }
+    if (!uuidstr_t_equals_t(&controller->uuid, uuid)) { return; }
     if (!controller->base.managed->obj_created) { return; }
     lv_btnmatrix_clear_btn_ctrl_all(controller->actions, LV_BTNMATRIX_CTRL_DISABLED);
 }
 
 static void send_wol_cb(int result, const char *error, const uuidstr_t *uuid, void *userdata) {
-    apps_fragment_t *controller = (apps_fragment_t *) userdata;
-    if (controller != current_instance) { return; }
+    LV_UNUSED(userdata);
+    apps_fragment_t *controller = current_instance;
+    if (controller == NULL) { return; }
+    if (!uuidstr_t_equals_t(&controller->uuid, uuid)) { return; }
     if (!controller->base.managed->obj_created) { return; }
     lv_btnmatrix_clear_btn_ctrl_all(controller->actions, LV_BTNMATRIX_CTRL_DISABLED);
     const SERVER_STATE *state = pcmanager_state(pcmanager, &controller->uuid);
     if (state == NULL) { return; }
     if (state->code & SERVER_STATE_ONLINE || result != GS_OK) { return; }
-    pcmanager_request_update(pcmanager, &controller->uuid, host_info_cb, controller);
+    pcmanager_request_update(pcmanager, &controller->uuid, host_info_cb, NULL);
 }
 
 static void update_view_state(apps_fragment_t *controller) {
@@ -601,7 +605,7 @@ static void launcher_toggle_hidden(apps_fragment_t *controller, const apploader_
 
 static void launcher_quit_game(apps_fragment_t *controller) {
     controller->quit_progress = progress_dialog_create(locstr("Quitting game..."));
-    pcmanager_quitapp(pcmanager, &controller->uuid, quitgame_cb, controller);
+    pcmanager_quitapp(pcmanager, &controller->uuid, quitgame_cb, NULL);
 }
 
 static int adapter_item_count(lv_obj_t *grid, void *data) {
@@ -651,7 +655,10 @@ static void applist_focus_leave(lv_event_t *event) {
 }
 
 static void quitgame_cb(int result, const char *error, const uuidstr_t *uuid, void *userdata) {
-    apps_fragment_t *controller = userdata;
+    LV_UNUSED(userdata);
+    apps_fragment_t *controller = current_instance;
+    if (controller == NULL) { return; }
+    if (!uuidstr_t_equals_t(&controller->uuid, uuid)) { return; }
     if (controller->quit_progress) {
         lv_msgbox_close(controller->quit_progress);
         controller->quit_progress = NULL;
@@ -683,13 +690,13 @@ static void actions_click_cb(lv_event_t *event) {
 static void action_cb_wol(apps_fragment_t *controller, lv_obj_t *buttons, uint16_t index) {
     LV_UNUSED(index);
     lv_btnmatrix_set_btn_ctrl_all(buttons, LV_BTNMATRIX_CTRL_DISABLED);
-    pcmanager_send_wol(pcmanager, &controller->uuid, send_wol_cb, controller);
+    pcmanager_send_wol(pcmanager, &controller->uuid, send_wol_cb, NULL);
 }
 
 static void action_cb_host_reload(apps_fragment_t *controller, lv_obj_t *buttons, uint16_t index) {
     LV_UNUSED(index);
     lv_btnmatrix_set_btn_ctrl_all(buttons, LV_BTNMATRIX_CTRL_DISABLED);
-    pcmanager_request_update(pcmanager, &controller->uuid, host_info_cb, controller);
+    pcmanager_request_update(pcmanager, &controller->uuid, host_info_cb, NULL);
 }
 
 static void action_cb_pair(apps_fragment_t *controller, lv_obj_t *buttons, uint16_t index) {


### PR DESCRIPTION
## Summary

The three pcmanager async callbacks in `apps.controller.c` — `host_info_cb`, `send_wol_cb`, `quitgame_cb` — received the `apps_fragment_t*` via their `userdata`. The fragment can be destroyed while a worker request is still in flight (WOL routinely waits 30+ seconds for the host to come up; Quit takes 1–5 seconds; navigating away or forgetting the host destroys the fragment in the meantime).

- `host_info_cb` and `send_wol_cb` guarded with `if (controller \!= current_instance) return`. The compare-only never dereferences, but it does *load* the freed pointer to compare — ASan/UBSan-visible UB, and there's a subtle re-allocation hazard where a new `apps_fragment` happens to land at the same address as the old one and the guard spuriously matches.
- `quitgame_cb` had **no guard at all** and went straight to `controller->quit_progress` and `controller->applist`. If the fragment was gone, the deref crashed. Plausibly the cause of some \"can't reproduce\" crash reports involving Quit followed by quick navigation.

Apploader's async callbacks don't have this issue because `apploader_destroy` zeros its callback table before unref. pcmanager has no equivalent invalidation hook.

## Fix

Pass `NULL` as userdata, and have each callback look up the fragment through the static `current_instance` pointer + uuid match. `current_instance` is set in `on_view_created` and cleared in `on_destroy_view` — same LVGL/UI thread as the bus-delivered callback, so no cross-thread race. No memory is ever read through the dangling userdata.

```c
// Before
pcmanager_quitapp(pcmanager, &controller->uuid, quitgame_cb, controller);
static void quitgame_cb(int result, ..., void *userdata) {
    apps_fragment_t *controller = userdata;  // UAF risk
    if (controller->quit_progress) { ... }   // crash if fragment gone
}

// After
pcmanager_quitapp(pcmanager, &controller->uuid, quitgame_cb, NULL);
static void quitgame_cb(int result, ..., const uuidstr_t *uuid, void *userdata) {
    LV_UNUSED(userdata);
    apps_fragment_t *controller = current_instance;
    if (controller == NULL) return;
    if (\!uuidstr_t_equals_t(&controller->uuid, uuid)) return;
    if (controller->quit_progress) { ... }
}
```

## Test plan
- [ ] Click Quit on a running game, then immediately back out of the apps view before the response arrives (need a 1-2s window). Previously: crash; now: response is dropped silently.
- [ ] Click Wake (WOL) on an offline host, then back out before the host comes up (~30s window). Previously: silent UB on pointer compare; now: response is dropped silently.
- [ ] Forget a host while a WOL request for it is in flight. Previously: `send_wol_cb` reads freed pointer; now: `on_destroy_view` clears `current_instance` first, callback bails.
- [ ] Normal flow (no navigation during async) still works: Wake an offline host → host comes up → state transitions to AVAILABLE → apploader loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
