### PR TITLE
fix(audio): handle calloc failure in aud_init

### DIFF
--- a/src/app/stream/audio/session_audio.c
+++ b/src/app/stream/audio/session_audio.c
@@ -40,7 +40,10 @@ static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATIO
         codec = SS4S_AUDIO_OPUS;
         decoder = NULL;
         buffer = calloc(1024, sizeof(unsigned char));
-        assert(buffer != NULL);
+        if (buffer == NULL) {
+            commons_log_error("Session", "Audio init: failed to allocate codec data buffer");
+            return -1;
+        }
         codecDataLen = opus_head_serialize(opusConfig, buffer);
     } else {
         int rc;
@@ -52,6 +55,12 @@ static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATIO
         frame_size = opusConfig->samplesPerFrame;
         unit_size = (int) (opusConfig->channelCount * sizeof(int16_t));
         buffer = calloc(unit_size, frame_size);
+        if (buffer == NULL) {
+            commons_log_error("Session", "Audio init: failed to allocate decode buffer");
+            opus_multistream_decoder_destroy(decoder);
+            decoder = NULL;
+            return -1;
+        }
     }
     audio_stream_info.format = SS4S_AudioCodecName(codec);
     switch (audioConfiguration) {


### PR DESCRIPTION
## Summary

`session_audio.c` had two `calloc` sites in `aud_init`:

1. The Opus passthrough path (line 42) used `assert(buffer != NULL)`. In release builds the assert is a no-op, so on `calloc` failure `opus_head_serialize()` ran with a NULL destination and faulted.
2. The PCM/decoded path (line 54) had no check at all. On `calloc` failure `aud_feed()` later called `opus_multistream_decode()` with `buffer = NULL` as the output and faulted.

Replace the assert with an early return that logs and propagates a non-zero error code (the same convention Limelight uses elsewhere in this file). On the PCM path, also destroy the opus decoder we already created before returning, so we don't leak it.

OOM during stream start is rare on webOS but not impossible after a long session — heap fragmentation accumulates and a 50+ MB malloc by the decoder backend can fail even when total free memory is well above that. The fix turns the crash into a clean "audio failed to init" error and lets the worker tear down gracefully.

## Test plan
- [x] `cmake --build build/webos-debug --target moonlight` links clean.
- [ ] Normal stream start (no OOM) — no regression expected; the fix only changes the error path.
- [ ] If you have a way to force calloc failure (e.g. via LD_PRELOAD malloc shim or an injected `MALLOC_PERTURB_` failure mode), confirm the session worker reports "Audio init: failed to allocate ..." in the log and the stream tears down cleanly instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
