### PR TITLE
fix: skip NDL HDR disable for MAIN10 to prevent decoder crash

### DIFF
--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -187,7 +187,19 @@ void streaming_set_hdr(session_t *session, bool hdr) {
     commons_log_info("Session", "HDR is %s", hdr ? "enabled" : "disabled");
     SS_HDR_METADATA hdr_metadata;
     if (!hdr) {
-        SS4S_PlayerVideoSetHDRInfo(session->player, NULL);
+        // If the stream was opened as MAIN10, the NDL pipeline is already in HDR
+        // mode. Passing NULL to SS4S_PlayerVideoSetHDRInfo triggers a full
+        // NDL_DirectMediaUnload + NDL_DirectMediaLoad cycle (see
+        // third_party/ss4s/modules/webos/ndl/webos5/ndl_video.c:SetHDRInfo),
+        // which races with the active stream and crashes the decoder. Since the
+        // server is still sending a 10-bit bitstream, leave the HDR display
+        // pipeline active and ignore the disable request.
+        bool is_main10 = session->config.stream.supportedVideoFormats &
+                         (VIDEO_FORMAT_H265_MAIN10 | VIDEO_FORMAT_AV1_MAIN10);
+        if (!is_main10) {
+            SS4S_PlayerVideoSetHDRInfo(session->player, NULL);
+        }
+        return;
     } else if (LiGetHdrMetadata(&hdr_metadata)) {
         SS4S_VideoHDRInfo info = {
                 .displayPrimariesX = {


### PR DESCRIPTION
👋 maintainer of https://github.com/hgaiser/moonshine here, a Linux-only server for streaming games using the Moonlight protocol. I recently changed the HDR pipeline to dynamically send either SDR or HDR content, depending on what type of frame data was received. This caused an [issue](https://github.com/hgaiser/moonshine/issues/61) on moonlight-tv where it would crash.

On webOS 5 (and presumably others), calling `SS4S_PlayerVideoSetHDRInfo(player, NULL)` while a MAIN10 stream is active triggers a full `NDL_DirectMediaUnload` + `NDL_DirectMediaLoad` cycle, which races with the active stream and causes the decoder to crash.

This happens in practice when streaming an SDR application (e.g. Steam) with HDR enabled on the host: the server opens the stream as MAIN10, then sends `HdrMode { enabled: false }` shortly after, causing the client to disable HDR and crash.

When the stream was negotiated as H265_MAIN10 or AV1_MAIN10, skip the NULL call on HDR disable. The NDL pipeline stays in HDR mode, which is correct since the server continues sending a 10-bit bitstream regardless.

Effectively this keeps the TV in HDR mode when a HDR session is started, relying on the TV to do SDR -> HDR mapping when SDR content is received. This seems to be the only way to get this to work on LG TVs.