### PR TITLE
fix(video): treat NOT_READY as transient with one IDR on resume

### DIFF
--- a/src/app/stream/video/session_video.c
+++ b/src/app/stream/video/session_video.c
@@ -29,6 +29,12 @@ static SS4S_Player *player = NULL;
 static unsigned char *buffer = NULL;
 static size_t buffer_size = 0;
 static int lastFrameNumber;
+// Set when SS4S_PlayerVideoFeed returns NOT_READY (decoder is in an
+// exclusive op like HDR toggle or resolution change). Consumed on the
+// next successful Feed: we ask Limelight for one IDR so the decoder
+// can resync from a known-good keyframe instead of decoding the next
+// P-frame against a discontinuity.
+static bool need_idr_on_resume = false;
 static struct VIDEO_STATS vdec_temp_stats;
 static int vdec_stream_format = 0;
 VIDEO_STATS vdec_summary_stats;
@@ -80,6 +86,7 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
     vdec_stream_format = videoFormat;
     vdec_stream_info.format = video_format_name(videoFormat);
     lastFrameNumber = 0;
+    need_idr_on_resume = false;
     SS4S_VideoInfo info = {
             .width = width,
             .height = height,
@@ -191,9 +198,27 @@ int vdec_delegate_submit(PDECODE_UNIT decodeUnit) {
         }
         vdec_temp_stats.totalSubmitTime += LiGetMillis() - decodeUnit->enqueueTimeMs;
         vdec_temp_stats.submittedFrames++;
+        if (need_idr_on_resume) {
+            // We dropped at least one frame while the decoder was in a
+            // brief exclusive op (HDR toggle, SizeChanged). Ask for one
+            // IDR so the next frame the decoder sees is a known-good
+            // keyframe instead of a P-frame referencing missing data.
+            need_idr_on_resume = false;
+            return DR_NEED_IDR;
+        }
         return DR_OK;
     } else if (result == SS4S_VIDEO_FEED_REQUEST_KEYFRAME) {
         return DR_NEED_IDR;
+    } else if (result == SS4S_VIDEO_FEED_NOT_READY) {
+        // Transient: the ss4s FeedGuard is in an exclusive op
+        // (SetHDRInfo / SizeChanged on a driver that does Unload+Load
+        // internally). Drop the frame silently; set the flag so the
+        // next successful Feed requests an IDR. This avoids tearing
+        // down the stream on a routine HDR toggle, and avoids spamming
+        // NEED_IDR on every dropped frame for the duration of the
+        // toggle.
+        need_idr_on_resume = true;
+        return DR_OK;
     } else {
         commons_log_error("Session", "Video feed error %d", result);
         session_interrupt(session, false, STREAMING_INTERRUPT_DECODER);


### PR DESCRIPTION
## Summary

Companion to ss4s [#16 (FeedGuard exclusive primitive)](https://github.com/mariotaku/ss4s/pull/16) — closes the original race that #593 worked around, but does it correctly so HDR toggle and resolution changes actually work mid-stream instead of being silently suppressed.

## Background

`SS4S_PlayerVideoSetHDRInfo(NULL)` on `ndl-webos5` (and `SS4S_PlayerVideoSizeChanged` on most LG/NDL backends) internally calls `NDL_DirectMediaUnload + NDL_DirectMediaLoad`. Before ss4s #16, an in-flight `driver->Feed` could be running on the half-torn-down decoder and crash the stream. PR #593 worked around this by skipping the `SetHDRInfo(NULL)` call entirely for MAIN10 streams.

ss4s #16 added a proper drain primitive (`BeginExclusive` / `EndExclusive` on the `FeedGuard`): during the destructive op, `Feed` returns `SS4S_VIDEO_FEED_NOT_READY` so it never reaches the driver. But the app side still tears down the stream on `NOT_READY` because it falls into the default error path:

```c
} else {
    commons_log_error("Session", "Video feed error %d", result);
    session_interrupt(session, false, STREAMING_INTERRUPT_DECODER);
    return DR_OK;
}
```

So the race is gone, but every HDR toggle still kills the stream.

## Fix

Handle `NOT_READY` as a transient signal in `vdec_delegate_submit`:

| Feed return | New behavior |
|---|---|
| `OK` (first one after `NOT_READY`) | Return `DR_NEED_IDR` — server resends a keyframe so the decoder resyncs from known-good data instead of a P-frame referencing the gap |
| `OK` (steady state) | `DR_OK`, normal stats bookkeeping |
| `NOT_READY` | Drop the frame silently (`DR_OK`), set `need_idr_on_resume = true`. No `session_interrupt`, no `DR_NEED_IDR` spam — exactly one IDR request per outage no matter how long it lasts. |
| `REQUEST_KEYFRAME` | `DR_NEED_IDR` (existing) |
| Anything else | `session_interrupt(STREAMING_INTERRUPT_DECODER)` (existing — real driver errors still tear the stream down) |

Resets `need_idr_on_resume = false` in `vdec_delegate_setup` so stream restarts don't inherit stale state.

## Bumps

Submodule pin `60d980a2` → `ab442770`. Picks up:
- `fix(video): drain Feed during SetHDRInfo and SizeChanged (#16)` — the exclusive primitive this PR pairs with
- `ci: run tests on every push and pull request (#17)`
- `ci: add AddressSanitizer pipeline (with dynamic libasan) (#18)`

## Comparison with #593

| Aspect | #593 (skip on MAIN10) | this PR + ss4s #16 |
|---|---|---|
| Fixes the crash on MAIN10 HDR-off | ✅ | ✅ |
| Same fix for `SizeChanged` race | ❌ | ✅ (free — same primitive) |
| HDR can actually be disabled mid-stream on 8-bit streams | unchanged | ✅ |
| HDR can be disabled mid-stream on MAIN10 streams | ❌ (suppressed) | ✅ |
| Brief frame drop + IDR resync during toggle | n/a | ~ms of dropped frames, single IDR request, no tear-down |

Recommend closing #593 in favor of this combined fix.

## Test plan
- [x] `cmake --build build/webos-debug --target moonlight` clean
- [ ] Stream H.265 MAIN10 with HDR, toggle HDR off mid-stream — previously crashed (without #593) or no-op'd (with #593); should now show ~brief gap then keyframe, stream continues with TV in SDR mode
- [ ] Stream H.264 (8-bit), toggle HDR off — should show brief gap then continue (with #593 alone this already worked)
- [ ] Change stream resolution mid-stream — `SizeChanged` uses the same primitive; should also survive without tear-down (previously this race was latent — same shape as the HDR one but no one had hit it)
- [ ] Regular streaming with no HDR/size events — should be byte-for-byte identical to before (only `NOT_READY` path is new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
