### PR TITLE
ci(webos): restrict ares-package and toolbox download to amd64 .deb

### DIFF
--- a/.github/workflows/build-webos.yml
+++ b/.github/workflows/build-webos.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: "webosbrew/ares-cli-rs"
           latest: true
-          fileName: "ares-package_*.deb"
+          fileName: "ares-package_*_amd64.deb"
           out-file-path: "temp"
 
       - name: Download Homebrew Toolbox
@@ -40,7 +40,7 @@ jobs:
         with:
           repository: "webosbrew/dev-toolbox-cli"
           latest: true
-          fileName: "webosbrew-toolbox-*.deb"
+          fileName: "webosbrew-toolbox-*_amd64.deb"
           out-file-path: "temp"
 
       - name: Update Packages


### PR DESCRIPTION
## Summary

`Build (webOS)` has been failing on every PR since [webosbrew/ares-cli-rs](https://github.com/webosbrew/ares-cli-rs) started publishing arm64 `.deb` artifacts alongside amd64. The `Install Tools` step does `sudo apt-get install ./temp/*.deb` after `release-downloader` pulls both architectures, producing:

```
ares-package       : Conflicts: ares-package:arm64 but 0.1.4-1 is to be installed
ares-package:arm64 : Depends: libc6:arm64 (>= 2.34) but it is not installable
##[error]Process completed with exit code 100.
```

Pin both download globs to `*_amd64.deb` so only the runner-native package is fetched.

```diff
-          fileName: "ares-package_*.deb"
+          fileName: "ares-package_*_amd64.deb"
...
-          fileName: "webosbrew-toolbox-*.deb"
+          fileName: "webosbrew-toolbox-*_amd64.deb"
```

The toolbox doesn't currently ship arm64, but the pattern is symmetric so it's future-proof.

## Test plan
- [ ] PR CI fires the `Build (webOS)` workflow and goes green (it failed on every recent PR — including #594 — with the apt conflict above)
- [ ] If/when the workflow moves to an arm64 runner, the glob will need to become `*_${{ runner.arch }}.deb` (or a small mapping step); flagging this as a future concern but not in scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
