### PR TITLE
deps: bump moonlight-common-c and adapt to the µs timing API

### DIFF
--- a/src/app/stream/session.h
+++ b/src/app/stream/session.h
@@ -29,8 +29,8 @@ typedef struct VIDEO_STATS {
     uint32_t receivedFrames;
     uint32_t networkDroppedFrames;
     uint32_t submittedFrames;
-    uint32_t totalReassemblyTime;
-    uint32_t totalSubmitTime;
+    uint32_t totalReassemblyTimeUs;
+    uint32_t totalSubmitTimeUs;
     unsigned long measurementStartTimestamp;
     uint32_t totalCaptureLatency;
     float totalFps;

--- a/src/app/stream/video/session_video.c
+++ b/src/app/stream/video/session_video.c
@@ -173,7 +173,7 @@ int vdec_delegate_submit(PDECODE_UNIT decodeUnit) {
     vdec_temp_stats.totalFrames++;
 
     vdec_temp_stats.totalCaptureLatency += decodeUnit->frameHostProcessingLatency;
-    vdec_temp_stats.totalReassemblyTime += decodeUnit->enqueueTimeMs - decodeUnit->receiveTimeMs;
+    vdec_temp_stats.totalReassemblyTimeUs += (uint32_t) (decodeUnit->enqueueTimeUs - decodeUnit->receiveTimeUs);
     vdec_stream_info.has_host_latency |= decodeUnit->frameHostProcessingLatency > 0;
     size_t length = 0;
     for (PLENTRY entry = decodeUnit->bufferList; entry != NULL; entry = entry->next) {
@@ -189,7 +189,7 @@ int vdec_delegate_submit(PDECODE_UNIT decodeUnit) {
         if (vdec_stream_info.width == 0 || vdec_stream_info.height == 0) {
             stream_info_parse_size(decodeUnit, &vdec_stream_info);
         }
-        vdec_temp_stats.totalSubmitTime += LiGetMillis() - decodeUnit->enqueueTimeMs;
+        vdec_temp_stats.totalSubmitTimeUs += (uint32_t) (LiGetMicroseconds() - decodeUnit->enqueueTimeUs);
         vdec_temp_stats.submittedFrames++;
         return DR_OK;
     } else if (result == SS4S_VIDEO_FEED_REQUEST_KEYFRAME) {

--- a/src/app/stream/video/session_video.c
+++ b/src/app/stream/video/session_video.c
@@ -189,6 +189,9 @@ int vdec_delegate_submit(PDECODE_UNIT decodeUnit) {
         if (vdec_stream_info.width == 0 || vdec_stream_info.height == 0) {
             stream_info_parse_size(decodeUnit, &vdec_stream_info);
         }
+        // Both sides come from PltGetMicroseconds(), so they share an epoch. Limelight.h documents
+        // neither that fact nor a supported way to age enqueueTimeUs, so re-check this subtraction
+        // whenever moonlight-common-c is bumped: a different clock underflows it silently.
         vdec_temp_stats.totalSubmitTimeUs += (uint32_t) (LiGetMicroseconds() - decodeUnit->enqueueTimeUs);
         vdec_temp_stats.submittedFrames++;
         return DR_OK;

--- a/src/app/ui/streaming/streaming.controller.c
+++ b/src/app/ui/streaming/streaming.controller.c
@@ -93,7 +93,7 @@ bool streaming_refresh_stats() {
             lv_label_set_text_fmt(controller->stats_items.host_latency, "not available");
         }
         if (vdec_stream_info.has_decoder_latency) {
-            float avgSubmitTime = (float) dst->totalSubmitTime / (float) dst->submittedFrames;
+            float avgSubmitTime = (float) dst->totalSubmitTimeUs / (float) dst->submittedFrames / 1000.0f;
             lv_label_set_text_fmt(controller->stats_items.vdec_latency, "avg %.2f ms",
                                   avgSubmitTime + dst->avgDecoderLatency);
         } else {


### PR DESCRIPTION
Moves `core/moonlight-common-c` from `c86e0537` to `e41355ea` — 40 commits, clean fast-forward, no divergence — and adapts the two call sites that the API change breaks.

> [!IMPORTANT]
> **Not built, not tested.** I have neither a webOS toolchain nor a streaming host available, so neither the armv7 build nor the corrected latency readout has been exercised. Both need to pass before this merges. Everything below is static verification against the pinned sources.

## Why

In rough order of value for this project:

- **Reed-Solomon FEC decoding now goes through `nanors` with SIMD**, including an explicit path for non-x86 targets. FEC runs per packet on the inbound video stream, so this is the kind of work that matters on the ARM SoCs webOS TVs use. This is the main reason to take the bump.
- The ENet mutex is no longer taken to query RTT, and mouse/gamepad batching locking was reworked — less contention on the network and input paths.
- Thread context and `pthread_attr` leaks fixed.
- RTSP handling hardened against malformed `Session` headers and oversized responses.
- CMake max version specified for cmake-4.0 support.

## The API break, and the trap in it

`DECODE_UNIT` renamed two fields this codebase consumes and switched them from milliseconds to microseconds:

```
receiveTimeMs -> receiveTimeUs
enqueueTimeMs -> enqueueTimeUs
```

The rename alone is a compile error, which is the easy part. The trap is that `session_video.c` computed submit time as `LiGetMillis() - decodeUnit->enqueueTimeMs`. A mechanical rename leaves **milliseconds minus microseconds** — it still compiles, it is silently 1000× off, and it feeds the `avg N ms` video latency readout in the stats overlay.

Upstream added `LiGetMicroseconds()` for exactly this. The accumulators now stay in microseconds end to end and the conversion happens once at display time, mirroring how `avgDecoderLatency` already handles its `latencyUs` input. `VIDEO_STATS` fields are renamed to carry the unit in the name (`totalSubmitTimeUs`, `totalReassemblyTimeUs`) so the next reader doesn't have to guess.

One side effect worth expecting: the video latency figure previously accumulated whole milliseconds per frame and truncated, so sub-millisecond submit times displayed as `0.00`. It will now show real values. That is a correction, not a regression, but the number on screen will change.

## What was verified statically

- `STREAM_CONFIGURATION` and all three callback structs are **byte-identical** to the pinned version.
- All **20 `Li*` symbols** this codebase calls still exist, with unchanged signatures.
- A repo-wide grep confirms the two renamed fields are the entire breaking surface — nothing outside `src/`, including `core/libgamestream`, touches them.
- All **7 CI checkouts** use `submodules: recursive` and both `easy_build.sh` scripts use `--init --recursive`, so the new nested `nanors` submodule is fetched everywhere. No workflow change needed.
- The new `cmake_minimum_required(3.1...4.0)` and `C_STANDARD 11` are compatible with this repo's root `3.19`.

## For reviewers

**The unproven part is the build.** `moonlight-common-c` gains a nested submodule (`nanors`) whose sources — including `deps/obl/oblas_*.c` — are compiled directly, with SIMD dispatched internally and no architecture conditionals in its CMake. This is the first time that path is built for `arm-webos-linux-gnueabi` here. CI is the fastest way to answer it.

The second commit only adds a comment. `Limelight.h` now states that `LiGetMicroseconds()` "should only ever be compared with the return value from a previous call to itself", and it dropped the old explicit guarantee that `enqueueTime` shares that epoch. The subtraction is correct today — `VideoDepacketizer.c` sets `enqueueTimeUs = PltGetMicroseconds()` and `Misc.c` defines `LiGetMicroseconds()` as a passthrough to the same clock — but nothing in the API promises it stays that way, and a future mismatch would underflow into a truncated garbage latency with no compile error. The comment records that so the next bump re-checks it.

Two pre-existing issues were found in the touched functions and deliberately left alone, both worth a separate PR:

- `totalCaptureLatency` accumulates per *received* frame ([session_video.c:175](https://github.com/mariotaku/moonlight-tv/blob/main/src/app/stream/video/session_video.c#L175)) but is divided by `submittedFrames` at display, so the host-latency average inflates whenever SS4S rejects frames — i.e. exactly when the stream is struggling.
- `totalReassemblyTimeUs` is written every frame and never read anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
