### PR TITLE
ci: run build workflows for pull requests

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -7,6 +7,14 @@ on:
       - 'v*.*.*'
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
@@ -15,6 +23,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    # Branches of this repository are already built by the push trigger,
+    # so only build pull requests opened from forks.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - name: Checkout Source

--- a/.github/workflows/build-raspberrypi.yml
+++ b/.github/workflows/build-raspberrypi.yml
@@ -7,6 +7,14 @@ on:
       - 'v*.*.*'
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
@@ -15,6 +23,9 @@ jobs:
   build:
     name: Build (${{ matrix.arch }})
     runs-on: ubuntu-22.04
+    # Branches of this repository are already built by the push trigger,
+    # so only build pull requests opened from forks.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
 
     strategy:
       matrix:
@@ -23,7 +34,9 @@ jobs:
     steps:
       - name: Set Short Commit ID
         shell: bash
-        run: echo SHORT_SHA="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+        run: echo SHORT_SHA="${HEAD_SHA:0:8}" >> $GITHUB_ENV
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout Source
         uses: actions/checkout@v4

--- a/.github/workflows/build-steamlink.yml
+++ b/.github/workflows/build-steamlink.yml
@@ -7,6 +7,14 @@ on:
       - 'v*.*.*'
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
@@ -15,11 +23,16 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
+    # Branches of this repository are already built by the push trigger,
+    # so only build pull requests opened from forks.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - name: Set Short Commit ID
         shell: bash
-        run: echo SHORT_SHA="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+        run: echo SHORT_SHA="${HEAD_SHA:0:8}" >> $GITHUB_ENV
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout Source
         uses: actions/checkout@v4

--- a/.github/workflows/build-webos.yml
+++ b/.github/workflows/build-webos.yml
@@ -7,6 +7,14 @@ on:
       - 'v*.*.*'
     branches:
       - '**'
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
@@ -15,11 +23,16 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    # Branches of this repository are already built by the push trigger,
+    # so only build pull requests opened from forks.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
 
     steps:
       - name: Set Short Commit ID
         shell: bash
-        run: echo SHORT_SHA="${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+        run: echo SHORT_SHA="${HEAD_SHA:0:8}" >> $GITHUB_ENV
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Checkout Source
         uses: actions/checkout@v4


### PR DESCRIPTION
The build workflows only triggered on push, so pull requests opened from
forks never got any checks. Add a `pull_request` trigger to all four build
workflows, skipping pull requests whose head is a branch of this repository
since those are already covered by the push trigger.

Also add a concurrency group so superseded runs get cancelled, and derive
SHORT_SHA from the pull request head commit instead of the synthetic merge
commit so artifact names stay meaningful.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XnzKwVqN5EkVaKQcZ7g86L