### PR TITLE
build: restore the monotonic clock in moonlight-common-c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,30 @@ endif ()
 
 set(BUILD_SHARED_LIBS ${BUILD_SHARED_CORE_LIBS})
 add_subdirectory(core/moonlight-common-c)
+
+# moonlight-common-c selects its monotonic clock with #ifdef HAVE_CLOCK_GETTIME, but its own
+# CMakeLists only computes that value and never passes it to the compiler. Without the definition
+# PltGetMillis() and PltGetMicroseconds() fall back to gettimeofday(), so every stream timeout,
+# dejitter wait and latency stat would run off a settable wall clock. Define it here until
+# upstream propagates its own check.
+include(CheckSymbolExists)
+check_symbol_exists(clock_gettime "time.h" MLCOMMON_HAVE_CLOCK_GETTIME)
+if (NOT MLCOMMON_HAVE_CLOCK_GETTIME)
+    # Before glibc 2.17 clock_gettime lives in librt rather than libc
+    set(CMAKE_REQUIRED_LIBRARIES rt)
+    check_symbol_exists(clock_gettime "time.h" MLCOMMON_HAVE_CLOCK_GETTIME_IN_RT)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+    if (MLCOMMON_HAVE_CLOCK_GETTIME_IN_RT)
+        target_link_libraries(moonlight-common-c PRIVATE rt)
+        set(MLCOMMON_HAVE_CLOCK_GETTIME ON)
+    endif ()
+endif ()
+if (MLCOMMON_HAVE_CLOCK_GETTIME)
+    target_compile_definitions(moonlight-common-c PRIVATE HAVE_CLOCK_GETTIME)
+else ()
+    message(WARNING "clock_gettime() is unavailable, moonlight-common-c will use a non-monotonic clock")
+endif ()
+
 add_subdirectory(core/libgamestream)
 if (BUILD_SHARED_LIBS)
     install(TARGETS moonlight-common-c LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Fixes a regression introduced by the `moonlight-common-c` bump in #603: on every platform this project ships, the library is now timing the stream off a settable wall clock instead of a monotonic one.

## What broke

Upstream moved the POSIX clock selection behind a preprocessor guard:

```c
#ifdef HAVE_CLOCK_GETTIME
    if (clock_gettime(PLT_MONOTONIC_CLOCK, &start_ts) == 0) {
        has_monotonic_time = true;
    } else
#endif
    {
        gettimeofday(&start_tv, NULL);
    }
```

Its `CMakeLists.txt` computes `HAVE_CLOCK_GETTIME` — and then never passes it to the compiler. There is no `target_compile_definitions`, no generated config header, no `add_definitions`. The variable is only ever read back by the `if()` a few lines further down in CMake itself, so the `#ifdef` is unconditionally false and `has_monotonic_time` stays `false`.

At the previous pin the same code read `#if defined(CLOCK_MONOTONIC) && !defined(NO_CLOCK_GETTIME)`, which `<time.h>` satisfies on Linux, so the monotonic path was always taken.

This is visible in the built object rather than only on paper:

| Pin | `Platform.c.o` undefined references |
| --- | --- |
| `c86e0537` (before the bump) | `clock_gettime` |
| `e41355ea` (current `main`) | `gettimeofday` |
| `e41355ea` + this change | `clock_gettime` |

## Why it matters

`PltGetMillis()` and `PltGetMicroseconds()` have 17 call sites across the video, audio, control and input paths. Several subtract two samples into an unsigned value, so a backwards clock step does not merely skew the result — it underflows:

- `RtpAudioQueue.c:547` — the dejitter wait. Underflow makes the comparison true immediately and flushes the queue.
- `VideoStream.c:171` — the first-frame timeout.
- `session_video.c:192` — `LiGetMicroseconds() - decodeUnit->enqueueTimeUs`, the video latency readout adapted in #603.

A TV that NTP-syncs shortly after coming online is exactly the case that steps this clock, and it can land while a stream is already running.

## The change

Run the check in this project and define the macro for the target:

- Uses `MLCOMMON_*` variable names rather than `HAVE_CLOCK_GETTIME`. The submodule's own `CHECK_LIBRARY_EXISTS` already caches a variable under that exact name and runs first via `add_subdirectory`, so reusing it would make this silently inherit upstream's result — `check_symbol_exists` is a no-op when the variable is already set.
- Falls back to linking `librt`, where `clock_gettime` lived before glibc 2.17, in case an older sysroot turns up.
- Emits a CMake warning if neither path resolves, so this cannot quietly regress to the wall clock again.

The workaround is deliberately confined to this repository's `CMakeLists.txt`; the submodule stays at the upstream commit.

## Verification

- Desktop build configures and compiles clean.
- `ctest` is 17/20, identical to the pre-change baseline. The three failures (`test_gcdb_update`, `test_pref_fps`, `test_pref_res`) are sandbox artifacts — a blocked HTTPS fetch of `gamecontrollerdb.txt` and a headless SDL assert — and are unrelated to this change.
- The check was also run under an `arm-linux-gnueabihf` toolchain file to confirm it resolves in a cross build rather than falling through to the warning, since that is the path the webOS, Raspberry Pi and Steam Link jobs take.

Not verified: behaviour against a real streaming host, and the webOS/Pi/Steam Link builds themselves. CI covers the latter.

The underlying bug is upstream's, and the proper fix is for `moonlight-common-c` to propagate its own check. Not filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnzKwVqN5EkVaKQcZ7g86L)_