### PR TITLE
ci(webos): bump buildroot NDK to webos-a38c582

### DIFF
--- a/.github/actions/build-webos/action.yml
+++ b/.github/actions/build-webos/action.yml
@@ -17,8 +17,8 @@ runs:
       uses: robinraju/release-downloader@v1.12
       with:
         repository: openlgtv/buildroot-nc4
-        tag: webos-b17b4cc
-        fileName: arm-webos-linux-gnueabi_sdk-buildroot.tar.gz
+        tag: webos-a38c582
+        fileName: arm-webos-linux-gnueabi_sdk-buildroot-x86_64.tar.gz
         out-file-path: /tmp
         extract: true
 


### PR DESCRIPTION
The webOS NDK was pinned to `webos-b17b4cc` from **2024-05-29**, two releases behind. This moves it to `webos-a38c582`.

| Tag | Date | Brings |
|---|---|---|
| `webos-b17b4cc` | 2024‑05‑29 | current pin |
| `webos-36b9236` | 2025‑07‑03 | buildroot 2025.02.01, **gcc 14**, libfrida-gum build fix |
| `webos-a38c582` | 2025‑07‑27 | renamed release artifacts, https support fix for cmake/python3 |

## Why this is two lines and not one

Release assets are now suffixed with the host arch. Changing only `tag:` would leave `fileName:` matching nothing, and the download step would silently find no file:

```
arm-webos-linux-gnueabi_sdk-buildroot.tar.gz          # before
arm-webos-linux-gnueabi_sdk-buildroot-x86_64.tar.gz   # after
```

`x86_64` is the right variant since the job runs on `ubuntu-latest`.

The paths in the relocate and toolchain steps are **deliberately left alone**. [openlgtv/buildroot-nc4#58](https://github.com/openlgtv/buildroot-nc4/pull/58) renames the archive with a `mv` *after* buildroot produces it, so the tarball contents are untouched and it still extracts to `arm-webos-linux-gnueabi_sdk-buildroot/`. I verified the asset exists under the new tag (330 MB) before changing the glob.

The tag lives in this composite action only — `release.yml` reuses it — so this is the single place it needed changing.

## What to watch

> [!IMPORTANT]
> **Not built, not tested.** gcc 14 is several major versions newer than what the old NDK shipped and is stricter about things gcc 12 accepted, so this may surface new warnings or errors.

The specific thing worth watching is **`nanors` and its `oblas` SIMD sources**. They arrived with the moonlight-common-c bump in #603 and have only ever been compiled here by the old toolchain, so this PR is the first time gcc 14 sees them. If the webOS build fails, that is the first place to look.

Now that 57a9574 added the `pull_request` trigger, CI validates this automatically — which is the whole point of opening it. If the build goes red on `nanors`, the fallback is `webos-36b9236` (gcc 14 without the artifact rename, so `fileName` would revert) or staying put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

