### PR TITLE
fix(video): fail cleanly when the decode buffer can't be allocated

### DIFF
--- a/src/app/stream/video/session_video.c
+++ b/src/app/stream/video/session_video.c
@@ -44,6 +44,8 @@ static void vdec_stat_submit(const struct VIDEO_STATS *src, unsigned long now);
 
 static void stream_info_parse_size(PDECODE_UNIT decodeUnit, struct VIDEO_INFO *info);
 
+static void vdec_buffer_free();
+
 DECODER_RENDERER_CALLBACKS ss4s_dec_callbacks = {
         .setup = vdec_delegate_setup,
         .cleanup = vdec_delegate_cleanup,
@@ -73,8 +75,16 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
     (void) drFlags;
     session = context;
     player = session->player;
+    buffer = malloc(DECODER_BUFFER_INITIAL_SIZE);
+    if (buffer == NULL) {
+        // Never leave buffer NULL while buffer_size advertises capacity: vdec_delegate_submit would
+        // skip the grow path and memcpy every frame into a NULL pointer.
+        commons_log_error("Session", "Failed to allocate %zu byte decode buffer",
+                          (size_t) DECODER_BUFFER_INITIAL_SIZE);
+        buffer_size = 0;
+        return CALLBACKS_SESSION_ERROR_VDEC_ERROR;
+    }
     buffer_size = DECODER_BUFFER_INITIAL_SIZE;
-    buffer = malloc(buffer_size);
     memset(&vdec_temp_stats, 0, sizeof(vdec_temp_stats));
     memset(&vdec_stream_info, 0, sizeof(vdec_stream_info));
     vdec_stream_format = videoFormat;
@@ -100,6 +110,9 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
             break;
         default: {
             commons_log_error("Session", "Unsupported codec %s", vdec_stream_info.format);
+            // vdec_delegate_cleanup only runs once the video stream has started, so every error
+            // return from here on must release the buffer itself.
+            vdec_buffer_free();
             return CALLBACKS_SESSION_ERROR_VDEC_UNSUPPORTED;
         }
     }
@@ -114,22 +127,30 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
             return 0;
         }
         case SS4S_VIDEO_OPEN_UNSUPPORTED_CODEC:
+            vdec_buffer_free();
             return CALLBACKS_SESSION_ERROR_VDEC_UNSUPPORTED;
         default:
+            vdec_buffer_free();
             return CALLBACKS_SESSION_ERROR_VDEC_ERROR;
     }
 }
 
 void vdec_delegate_cleanup() {
     assert(player != NULL);
-    free(buffer);
-    buffer = NULL;
-    buffer_size = 0;
+    vdec_buffer_free();
     SS4S_PlayerVideoClose(player);
     session = NULL;
 }
 
+void vdec_buffer_free() {
+    free(buffer);
+    buffer = NULL;
+    buffer_size = 0;
+}
+
 int vdec_delegate_submit(PDECODE_UNIT decodeUnit) {
+    // Guaranteed by vdec_delegate_setup: the stream never starts without a buffer.
+    assert(buffer != NULL);
     if ((size_t) decodeUnit->fullLength > buffer_size) {
         if ((size_t) decodeUnit->fullLength > DECODER_BUFFER_MAX_SIZE) {
             commons_log_error("Session", "Decode unit %d bytes exceeds %zu byte cap, dropping",

--- a/src/app/stream/video/session_video.c
+++ b/src/app/stream/video/session_video.c
@@ -75,16 +75,6 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
     (void) drFlags;
     session = context;
     player = session->player;
-    buffer = malloc(DECODER_BUFFER_INITIAL_SIZE);
-    if (buffer == NULL) {
-        // Never leave buffer NULL while buffer_size advertises capacity: vdec_delegate_submit would
-        // skip the grow path and memcpy every frame into a NULL pointer.
-        commons_log_error("Session", "Failed to allocate %zu byte decode buffer",
-                          (size_t) DECODER_BUFFER_INITIAL_SIZE);
-        buffer_size = 0;
-        return CALLBACKS_SESSION_ERROR_VDEC_ERROR;
-    }
-    buffer_size = DECODER_BUFFER_INITIAL_SIZE;
     memset(&vdec_temp_stats, 0, sizeof(vdec_temp_stats));
     memset(&vdec_stream_info, 0, sizeof(vdec_stream_info));
     vdec_stream_format = videoFormat;
@@ -110,12 +100,19 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
             break;
         default: {
             commons_log_error("Session", "Unsupported codec %s", vdec_stream_info.format);
-            // vdec_delegate_cleanup only runs once the video stream has started, so every error
-            // return from here on must release the buffer itself.
-            vdec_buffer_free();
             return CALLBACKS_SESSION_ERROR_VDEC_UNSUPPORTED;
         }
     }
+
+    // Leaving buffer NULL while buffer_size advertises capacity would make vdec_delegate_submit
+    // skip the grow path and memcpy every frame into a NULL pointer, so fail the stream instead.
+    buffer = malloc(DECODER_BUFFER_INITIAL_SIZE);
+    if (buffer == NULL) {
+        commons_log_error("Session", "Failed to allocate %zu byte decode buffer",
+                          (size_t) DECODER_BUFFER_INITIAL_SIZE);
+        return CALLBACKS_SESSION_ERROR_VDEC_ERROR;
+    }
+    buffer_size = DECODER_BUFFER_INITIAL_SIZE;
 
     app_t *app = session->app;
     if (app->ss4s.video_cap.transform & SS4S_VIDEO_CAP_TRANSFORM_UI_EXCLUSIVE) {
@@ -127,6 +124,8 @@ int vdec_delegate_setup(int videoFormat, int width, int height, int redrawRate, 
             return 0;
         }
         case SS4S_VIDEO_OPEN_UNSUPPORTED_CODEC:
+            // vdec_delegate_cleanup only runs once the video stream has started, so a failed
+            // setup has to release the buffer itself.
             vdec_buffer_free();
             return CALLBACKS_SESSION_ERROR_VDEC_UNSUPPORTED;
         default:
@@ -149,7 +148,6 @@ void vdec_buffer_free() {
 }
 
 int vdec_delegate_submit(PDECODE_UNIT decodeUnit) {
-    // Guaranteed by vdec_delegate_setup: the stream never starts without a buffer.
     assert(buffer != NULL);
     if ((size_t) decodeUnit->fullLength > buffer_size) {
         if ((size_t) decodeUnit->fullLength > DECODER_BUFFER_MAX_SIZE) {


### PR DESCRIPTION
## What

`vdec_delegate_setup()` set `buffer_size` to `DECODER_BUFFER_INITIAL_SIZE` and then assigned the result of `malloc()` without checking it:

```c
buffer_size = DECODER_BUFFER_INITIAL_SIZE;   // 2 MiB
buffer = malloc(buffer_size);                // unchecked
```

On allocation failure `buffer` stayed `NULL` while `buffer_size` kept advertising 2 MiB. In `vdec_delegate_submit()` the `fullLength > buffer_size` guard is then false for any normal frame, so the grow-on-demand path is skipped and the loop runs `memcpy(NULL, entry->data, entry->length)`.

This PR checks the allocation, leaves `buffer_size` at `0` so the invariant can't be broken, and returns `CALLBACKS_SESSION_ERROR_VDEC_ERROR` — the session then reports *"Failed to open video decoder"* instead of taking the whole app down.

It also fixes a leak on the same function's error returns. `vdec_delegate_cleanup()` is only reached via `stopVideoStream()`, which moonlight-common-c only calls once `startVideoStream()` has succeeded — so an error return from `setup()` leaked the 2 MiB buffer. Those paths now release it through a shared `vdec_buffer_free()` helper, which `cleanup()` uses too.

## Why

The leak is the reachable half. `buffer` is a file-scope static, so every error return from `setup()` strands 2 MiB that the next attempt's `malloc` overwrites — it accumulates once per failed start, and an unsupported codec reaches that path in normal use.

The NULL check is defensive hardening, not a fix for an observed failure: a failing 2 MiB allocation has not been seen in the field. It is cheap to keep because the current code turns that case into a `memcpy` to NULL rather than a clean error.

## Notes for reviewers

- **No crash report is being claimed here.** I have no webOS 2 hardware, so the NULL-`memcpy` is something proved by reading the code, not something reproduced. It stands as a correctness fix on its own merits.
- The other candidate I found is outside this repo: in `third_party/ss4s`, the `ndl-esplayer` module (auto-selected on 2.2.3 — weight 50, `OS_VERSION ">=2.2,<3.5"`) never validates `NDL_EsplayerCreate()`'s handle, and `LoadMedia()` only guards it with `assert()`, which is compiled out because releases build `RelWithDebInfo` (`-DNDEBUG`). If that returns `NULL` it ends up in `NDL_EsplayerFeedData(NULL, ...)`, which would produce the same NULL-pointer signature. Happy to open a matching PR against `mariotaku/ss4s` if you think it's worth it.
- The new `assert(buffer != NULL)` in `vdec_delegate_submit()` only documents the invariant; the `setup()` check is what actually enforces it in release builds.
- Not built locally (no webOS NDK on this machine) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
