### PR TITLE
fix(audio): release init buffers when opening the audio backend fails

### DIFF
--- a/src/app/stream/audio/session_audio.c
+++ b/src/app/stream/audio/session_audio.c
@@ -20,6 +20,8 @@ AUDIO_INFO audio_stream_info;
 
 static size_t opus_head_serialize(const OPUS_MULTISTREAM_CONFIGURATION *config, unsigned char *data);
 
+static void aud_buffers_free();
+
 static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATION opusConfig, void *context,
                     int arFlags) {
     (void) audioConfiguration;
@@ -57,8 +59,7 @@ static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATIO
         buffer = calloc(unit_size, frame_size);
         if (buffer == NULL) {
             commons_log_error("Session", "Audio init: failed to allocate decode buffer");
-            opus_multistream_decoder_destroy(decoder);
-            decoder = NULL;
+            aud_buffers_free();
             return -1;
         }
     }
@@ -80,7 +81,13 @@ static int aud_init(int audioConfiguration, const POPUS_MULTISTREAM_CONFIGURATIO
     info.codec = codec;
     info.codecData = buffer;
     info.codecDataLen = codecDataLen;
-    return SS4S_PlayerAudioOpen(player, &info);
+    // aud_cleanup only runs once the audio stream has started, so a failed init has to release
+    // what it allocated itself.
+    SS4S_AudioOpenResult result = SS4S_PlayerAudioOpen(player, &info);
+    if (result != SS4S_AUDIO_OPEN_OK) {
+        aud_buffers_free();
+    }
+    return result;
 }
 
 static void aud_cleanup() {
@@ -88,15 +95,17 @@ static void aud_cleanup() {
         SS4S_PlayerAudioClose(player);
         player = NULL;
     }
+    aud_buffers_free();
+    session = NULL;
+}
+
+static void aud_buffers_free() {
     if (decoder != NULL) {
         opus_multistream_decoder_destroy(decoder);
         decoder = NULL;
     }
-    if (buffer != NULL) {
-        free(buffer);
-        buffer = NULL;
-    }
-    session = NULL;
+    free(buffer);
+    buffer = NULL;
 }
 
 static void aud_feed(char *sampleData, int sampleLength) {


### PR DESCRIPTION
## What

`aud_init()` ended with a tail call:

```c
return SS4S_PlayerAudioOpen(player, &info);
```

`startAudioStream()` returns immediately when `AudioCallbacks.init()` reports an error and never calls `AudioCallbacks.cleanup()` ([AudioStream.c](https://github.com/moonlight-stream/moonlight-common-c/blob/master/src/AudioStream.c) — `err = AudioCallbacks.init(...); if (err != 0) { return err; }`). So when the backend fails to open, the sample buffer leaks, and on the PCM path the `OpusMSDecoder` leaks with it. The next stream attempt overwrites both file-scope statics, making the leak permanent and repeating it per attempt.

This releases them on that path through a shared `aud_buffers_free()`, which also replaces the hand-rolled decoder teardown on the decode-buffer allocation failure and the free/destroy half of `aud_cleanup()`.

The helper deliberately does **not** close the player: on the failing path there is no open audio instance to close, and `aud_cleanup()` still closes it first before calling the helper.

## Why

Same moonlight-common-c ownership contract as #609 (video), which fixes the mirror-image problem in `vdec_delegate_setup`. The two are independent — this one stands on its own and neither depends on the other.

## Notes for reviewers

- `SS4S_AUDIO_OPEN_OK` is `0`, so the return value's meaning to the caller is unchanged; the function now returns `SS4S_AudioOpenResult` through the same `int`.
- Dropping the `if (buffer != NULL)` guard around `free(buffer)` is intentional — `free(NULL)` is a no-op, and it matches the shape used on the video side.
- The two earlier error returns in `aud_init` (the Opus-branch `calloc` failure and a non-zero `rc` from `opus_multistream_decoder_create`) genuinely own nothing at that point, so they are left alone rather than given a no-op release call.
- Unrelated but adjacent, and **not** touched here: `aud_init` returns raw values (`-1`, an opus `rc`, an SS4S result) that never match the `CALLBACKS_SESSION_ERROR_ADEC_*` constants `session_worker.c` knows how to map, so audio failures surface as `"Limelight returned N"` with `strerror` applied to a non-errno value. Happy to send that as a separate PR if you want it.
- Not built locally (no webOS NDK on this machine) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
