### PR TITLE
Add configurable controller touchpad support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,20 @@ set(BUILD_SHARED_CORE_LIBS OFF)
 
 if (TARGET_WEBOS)
     set(CMAKE_INSTALL_LIBDIR lib/backports)
-    set(SDL2_BACKPORT_RELEASE "release-2.30.12-webos.5")
+    set(SDL2_BACKPORT_REVISION "9f30a1f01e4d36aa5d3e4e04df5921b7a9d093ee")
     include(ExternalSDL2BackportForWebOS)
+    find_package(Git REQUIRED)
+    ExternalProject_Add_Step(ext_sdl2_backport controller_reconnect_patch
+            COMMAND ${CMAKE_COMMAND}
+                    -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+                    -DSOURCE_DIR=<SOURCE_DIR>
+                    -DPATCH_FILE=${CMAKE_SOURCE_DIR}/cmake/patches/SDL-webOS-controller-reconnect.patch
+                    -P ${CMAKE_SOURCE_DIR}/cmake/ApplyGitPatch.cmake
+            WORKING_DIRECTORY <SOURCE_DIR>
+            DEPENDEES patch
+            DEPENDERS configure
+            COMMENT "Applying SDL-webOS controller reconnect patch"
+    )
     unset(CMAKE_INSTALL_LIBDIR)
 else ()
     pkg_check_modules(SDL2 REQUIRED sdl2>=2.0.4)

--- a/cmake/ApplyGitPatch.cmake
+++ b/cmake/ApplyGitPatch.cmake
@@ -1,0 +1,31 @@
+foreach (_required_var GIT_EXECUTABLE SOURCE_DIR PATCH_FILE)
+    if (NOT DEFINED ${_required_var})
+        message(FATAL_ERROR "${_required_var} is required")
+    endif ()
+endforeach ()
+
+# ExternalProject's git update step runs again when CPack builds the preinstall
+# target. Treat an already-applied patch as success so repeated builds remain
+# idempotent, while still failing if the source matches neither side.
+execute_process(
+        COMMAND "${GIT_EXECUTABLE}" apply --unidiff-zero --reverse --check "${PATCH_FILE}"
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE _reverse_check_result
+        OUTPUT_QUIET
+        ERROR_QUIET)
+if (_reverse_check_result EQUAL 0)
+    return()
+endif ()
+
+execute_process(
+        COMMAND "${GIT_EXECUTABLE}" apply --unidiff-zero --check "${PATCH_FILE}"
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        RESULT_VARIABLE _check_result)
+if (NOT _check_result EQUAL 0)
+    message(FATAL_ERROR "Patch cannot be applied cleanly: ${PATCH_FILE}")
+endif ()
+
+execute_process(
+        COMMAND "${GIT_EXECUTABLE}" apply --unidiff-zero "${PATCH_FILE}"
+        WORKING_DIRECTORY "${SOURCE_DIR}"
+        COMMAND_ERROR_IS_FATAL ANY)

--- a/cmake/patches/SDL-webOS-controller-reconnect.patch
+++ b/cmake/patches/SDL-webOS-controller-reconnect.patch
@@ -1,0 +1,73 @@
+diff --git a/src/joystick/linux/SDL_sysjoystick.c b/src/joystick/linux/SDL_sysjoystick.c
+--- a/src/joystick/linux/SDL_sysjoystick.c
++++ b/src/joystick/linux/SDL_sysjoystick.c
+@@ -936,13 +936,18 @@ static void LINUX_FallbackJoystickDetect(void)
+-        if (presence_flags != last_input_presence_flags) {
+-            char path[PATH_MAX];
+-            for (int i = 0; i < 32; i++) {
+-                if (SDL_webOSIsDeviceIndexPresent(presence_flags, i)) {
+-                    if (check == SDL_WEBOS_DEVICE_PRESENCE_CHECK_EVDEV) {
+-                        SDL_snprintf(path, SDL_arraysize(path), "/dev/input/event%d", i);
+-                    } else if (check == SDL_WEBOS_DEVICE_PRESENCE_CHECK_JS) {
+-                        SDL_snprintf(path, SDL_arraysize(path), "/dev/input/js%d", i);
+-                    } else {
+-                        break;
+-                    }
+-                    MaybeAddDevice(path);
+-                }
++        char path[PATH_MAX];
++        for (int i = 0; i < 32; i++) {
++            SDL_bool present = SDL_webOSIsDeviceIndexPresent(presence_flags, i);
++            SDL_bool was_present = SDL_webOSIsDeviceIndexPresent(last_input_presence_flags, i);
++            if (!present && !was_present) {
++                continue;
++            }
++            if (check == SDL_WEBOS_DEVICE_PRESENCE_CHECK_EVDEV) {
++                SDL_snprintf(path, SDL_arraysize(path), "/dev/input/event%d", i);
++            } else if (check == SDL_WEBOS_DEVICE_PRESENCE_CHECK_JS) {
++                SDL_snprintf(path, SDL_arraysize(path), "/dev/input/js%d", i);
++            } else {
++                break;
++            }
++            if (present) {
++                MaybeAddDevice(path);
++            } else {
++                MaybeRemoveDevice(path);
+@@ -950 +954,0 @@ static void LINUX_FallbackJoystickDetect(void)
+-            last_input_presence_flags = presence_flags;
+@@ -951,0 +956 @@ static void LINUX_FallbackJoystickDetect(void)
++        last_input_presence_flags = presence_flags;
+@@ -968,0 +974,6 @@ static void LINUX_JoystickDetect(void)
++#ifdef __WEBOS__
++    /* Drop stale devices before polling so the same devnode can be re-added. */
++    if (enumeration_method == ENUMERATION_POLLING) {
++        HandlePendingRemovals();
++    }
++#endif
+@@ -982,0 +994,5 @@ static void LINUX_JoystickDetect(void)
++#ifdef __WEBOS__
++    if (enumeration_method != ENUMERATION_POLLING) {
++        HandlePendingRemovals();
++    }
++#else
+@@ -983,0 +1000 @@ static void LINUX_JoystickDetect(void)
++#endif
+diff --git a/src/hidapi/SDL_hidapi.c b/src/hidapi/SDL_hidapi.c
+--- a/src/hidapi/SDL_hidapi.c
++++ b/src/hidapi/SDL_hidapi.c
+@@ -424,10 +424,11 @@ static void HIDAPI_UpdateDiscovery(void)
+         if (!SDL_HIDAPI_discovery.m_unLastDetect || SDL_TICKS_PASSED(now, next_detect)) {
+             // Loop through /dev/hidraw*
+             Uint32 flags = SDL_webOSGetDevicePresenceFlags(SDL_WEBOS_DEVICE_PRESENCE_CHECK_HIDRAW);
+-            if (flags != SDL_HIDAPI_discovery.m_unPresenceFlags) {
+-                ++SDL_HIDAPI_discovery.m_unDeviceChangeCounter;
+-                SDL_HIDAPI_discovery.m_unPresenceFlags = flags;
+-            }
++            /* A controller can disappear and return on the same hidraw index
++             * between polls, leaving the presence mask unchanged. Force the
++             * HIDAPI device list to be reconciled on each polling interval. */
++            SDL_HIDAPI_discovery.m_unPresenceFlags = flags;
++            ++SDL_HIDAPI_discovery.m_unDeviceChangeCounter;
+             SDL_HIDAPI_discovery.m_unLastDetect = now;
+         }
+     } else

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -62,6 +62,10 @@ int app_init(app_t *app, app_settings_loader *settings_loader, int argc, char *a
     backend_init(&app->backend, app);
 
 #if TARGET_WEBOS
+    /* Force SDL to use its webOS polling joystick discovery backend.
+     * Some webOS environments are misdetected as non-jailed and select udev,
+     * which can deliver removal without a matching add after Bluetooth reconnect. */
+    SDL_setenv("SDL_WEBOS_FORCE_JAILED", "1", 1);
     SDL_SetHint(SDL_HINT_WEBOS_ACCESS_POLICY_KEYS_BACK, "true");
     SDL_SetHint(SDL_HINT_WEBOS_ACCESS_POLICY_KEYS_EXIT, "true");
     SDL_SetHint(SDL_HINT_WEBOS_CURSOR_SLEEP_TIME, "5000");
@@ -273,6 +277,9 @@ static int app_event_filter(void *userdata, SDL_Event *event) {
 void app_process_events(app_t *app) {
     SDL_PumpEvents();
     SDL_FilterEvents(app_event_filter, app);
+    if (app->session != NULL) {
+        session_flush_input_events(app->session);
+    }
 }
 
 void app_quit_confirm() {

--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -22,12 +22,21 @@ static const char *serialize_audio_config(int config);
 
 static int parse_audio_config(const char *value);
 
+static const char *indexed_setting_serialize(const char *const values[], size_t count, int value, int fallback);
+
+static int indexed_setting_parse(const char *value, const char *const values[], size_t count, int fallback);
+
 static int settings_parse(app_settings_t *config, const char *section, const char *name, const char *value);
 
 static void set_string(char **field, const char *value);
 
 static void set_int(int *field, const char *value);
 
+
+#define SETTINGS_COUNT(values) (sizeof(values) / sizeof((values)[0]))
+
+static const char *const controller_touchpad_mode_values[] = {"off", "mouse", "native"};
+static const char *const controller_touchpad_press_values[] = {"off", "left", "right", "middle"};
 
 const audio_config_entry_t audio_configs[] = {
         {AUDIO_CONFIGURATION_STEREO,      "stereo", translatable("Stereo")},
@@ -67,6 +76,13 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->rotate = 0;
     config->absmouse = true;
     config->virtual_mouse = false;
+    config->controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_MOUSE;
+    config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT;
+    config->controller_touchpad_press = CONTROLLER_TOUCHPAD_PRESS_LEFT;
+    config->controller_touchpad_secondary_click = CONTROLLER_TOUCHPAD_PRESS_RIGHT;
+    config->controller_touchpad_tap_to_click = true;
+    config->controller_touchpad_two_finger_scroll = true;
+    config->controller_touchpad_invert_two_finger_scroll = true;
     config->hdr = false;
     config->hevc = true;
     config->av1 = false;
@@ -111,6 +127,28 @@ bool settings_save(app_settings_t *config) {
     ini_write_section(fp, "input");
     ini_write_bool(fp, "absmouse", config->absmouse);
     ini_write_bool(fp, "virtual_mouse", config->virtual_mouse);
+    ini_write_string(fp, "controller_touchpad",
+                     indexed_setting_serialize(controller_touchpad_mode_values,
+                                               SETTINGS_COUNT(controller_touchpad_mode_values),
+                                               config->controller_touchpad_mode, CONTROLLER_TOUCHPAD_MODE_MOUSE));
+#if TARGET_WEBOS
+    ini_write_bool(fp, "controller_touchpad_webos_touchscreen",
+                   config->controller_touchpad_webos_touchscreen);
+#endif
+    ini_write_int(fp, "controller_touchpad_sensitivity", config->controller_touchpad_sensitivity);
+    ini_write_string(fp, "controller_touchpad_press",
+                     indexed_setting_serialize(controller_touchpad_press_values,
+                                               SETTINGS_COUNT(controller_touchpad_press_values),
+                                               config->controller_touchpad_press, CONTROLLER_TOUCHPAD_PRESS_LEFT));
+    ini_write_string(fp, "controller_touchpad_secondary_click",
+                     indexed_setting_serialize(controller_touchpad_press_values,
+                                               SETTINGS_COUNT(controller_touchpad_press_values),
+                                               config->controller_touchpad_secondary_click, CONTROLLER_TOUCHPAD_PRESS_RIGHT));
+    ini_write_bool(fp, "controller_touchpad_tap_to_click", config->controller_touchpad_tap_to_click);
+    ini_write_bool(fp, "controller_touchpad_two_finger_scroll",
+                   config->controller_touchpad_two_finger_scroll);
+    ini_write_bool(fp, "controller_touchpad_invert_two_finger_scroll",
+                   config->controller_touchpad_invert_two_finger_scroll);
 #if FEATURE_INPUT_EVMOUSE
     ini_write_bool(fp, "hardware_mouse", config->hardware_mouse);
 #endif
@@ -221,6 +259,26 @@ int find_ch_idx_by_value(const char *value) {
     return -1;
 }
 
+static const char *indexed_setting_serialize(const char *const values[], size_t count,
+                                             int value, int fallback) {
+    if ((unsigned int) value >= count) {
+        value = fallback;
+    }
+    return values[value];
+}
+
+static int indexed_setting_parse(const char *value, const char *const values[],
+                                 size_t count, int fallback) {
+    if (value != NULL) {
+        for (size_t i = 0; i < count; ++i) {
+            if (strcmp(value, values[i]) == 0) {
+                return (int) i;
+            }
+        }
+    }
+    return fallback;
+}
+
 static int settings_parse(app_settings_t *config, const char *section, const char *name, const char *value) {
     if (INI_FULL_MATCH("streaming", "width")) {
         set_int(&config->stream.width, value);
@@ -254,6 +312,38 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         config->absmouse = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("virtual_mouse")) {
         config->virtual_mouse = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad")) {
+        config->controller_touchpad_mode = indexed_setting_parse(
+                value, controller_touchpad_mode_values,
+                SETTINGS_COUNT(controller_touchpad_mode_values),
+                CONTROLLER_TOUCHPAD_MODE_MOUSE);
+#if TARGET_WEBOS
+    } else if (INI_NAME_MATCH("controller_touchpad_webos_touchscreen")) {
+        config->controller_touchpad_webos_touchscreen = INI_IS_TRUE(value);
+#endif
+    } else if (INI_NAME_MATCH("controller_touchpad_sensitivity")) {
+        set_int(&config->controller_touchpad_sensitivity, value);
+        if (config->controller_touchpad_sensitivity < CONTROLLER_TOUCHPAD_SENSITIVITY_MIN) {
+            config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_MIN;
+        } else if (config->controller_touchpad_sensitivity > CONTROLLER_TOUCHPAD_SENSITIVITY_MAX) {
+            config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_MAX;
+        }
+    } else if (INI_NAME_MATCH("controller_touchpad_press")) {
+        config->controller_touchpad_press = indexed_setting_parse(
+                value, controller_touchpad_press_values,
+                SETTINGS_COUNT(controller_touchpad_press_values),
+                CONTROLLER_TOUCHPAD_PRESS_LEFT);
+    } else if (INI_NAME_MATCH("controller_touchpad_secondary_click")) {
+        config->controller_touchpad_secondary_click = indexed_setting_parse(
+                value, controller_touchpad_press_values,
+                SETTINGS_COUNT(controller_touchpad_press_values),
+                CONTROLLER_TOUCHPAD_PRESS_RIGHT);
+    } else if (INI_NAME_MATCH("controller_touchpad_tap_to_click")) {
+        config->controller_touchpad_tap_to_click = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad_two_finger_scroll")) {
+        config->controller_touchpad_two_finger_scroll = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad_invert_two_finger_scroll")) {
+        config->controller_touchpad_invert_two_finger_scroll = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("hardware_mouse")) {
 #if FEATURE_INPUT_EVMOUSE
         config->hardware_mouse = INI_IS_TRUE(value);

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -27,6 +27,23 @@ typedef struct window_state_t {
     int x, y, w, h;
 } window_state_t;
 
+enum {
+    CONTROLLER_TOUCHPAD_MODE_DISABLED = 0,
+    CONTROLLER_TOUCHPAD_MODE_MOUSE = 1,
+    CONTROLLER_TOUCHPAD_MODE_NATIVE = 2,
+};
+
+enum {
+    CONTROLLER_TOUCHPAD_PRESS_DISABLED = 0,
+    CONTROLLER_TOUCHPAD_PRESS_LEFT = 1,
+    CONTROLLER_TOUCHPAD_PRESS_RIGHT = 2,
+    CONTROLLER_TOUCHPAD_PRESS_MIDDLE = 3,
+};
+
+#define CONTROLLER_TOUCHPAD_SENSITIVITY_MIN 25
+#define CONTROLLER_TOUCHPAD_SENSITIVITY_MAX 200
+#define CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT 100
+
 typedef struct app_settings_t {
     STREAM_CONFIGURATION stream;
     int debug_level;
@@ -45,6 +62,14 @@ typedef struct app_settings_t {
     bool absmouse;
     bool hardware_mouse;
     bool virtual_mouse;
+    int controller_touchpad_mode;
+    int controller_touchpad_sensitivity;
+    int controller_touchpad_press;
+    int controller_touchpad_secondary_click;
+    bool controller_touchpad_webos_touchscreen;
+    bool controller_touchpad_tap_to_click;
+    bool controller_touchpad_two_finger_scroll;
+    bool controller_touchpad_invert_two_finger_scroll;
     bool swap_abxy;
     bool syskey_capture;
     bool hdr;

--- a/src/app/input/app_input.c
+++ b/src/app/input/app_input.c
@@ -14,7 +14,7 @@ void app_input_init(app_input_t *input, app_t *app) {
 #endif
     }
     SDL_InitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
-    input->max_num_gamepads = 4;
+    input->max_num_gamepads = sizeof(input->gamepads) / sizeof(input->gamepads[0]);
     input->gamepads_count = 0;
     for (int i = 0; i < input->max_num_gamepads; i++) {
         input->gamepads[i].instance_id = -1;

--- a/src/app/input/input_gamepad.c
+++ b/src/app/input/input_gamepad.c
@@ -82,6 +82,7 @@ app_gamepad_state_t *app_input_gamepad_state_init(app_input_t *input, SDL_GameCo
     SDL_Joystick *joystick = SDL_GameControllerGetJoystick(controller);
     SDL_JoystickID sdl_id = SDL_JoystickInstanceID(joystick);
 
+#if !SDL_VERSION_ATLEAST(2, 0, 9)
     SDL_Haptic *haptic = SDL_HapticOpenFromJoystick(joystick);
     unsigned int haptic_bits = SDL_HapticQuery(haptic);
     commons_log_debug("Input", "Controller #%d has supported haptic bits: %x", state->gs_id, haptic_bits);
@@ -89,6 +90,7 @@ app_gamepad_state_t *app_input_gamepad_state_init(app_input_t *input, SDL_GameCo
         SDL_HapticClose(haptic);
         haptic = NULL;
     }
+#endif
     state->instance_id = sdl_id;
     state->controller = controller;
     state->guid = SDL_JoystickGetGUID(joystick);

--- a/src/app/stream/input/session_gamepad.c
+++ b/src/app/stream/input/session_gamepad.c
@@ -1,7 +1,7 @@
-#include "app.h"
-
 #include <Limelight.h>
 
+#include "app_settings.h"
+#include "input/app_input.h"
 #include "stream/input/session_input.h"
 
 #include "util/bus.h"
@@ -13,6 +13,43 @@
 
 #define QUIT_BUTTONS (PLAY_FLAG | BACK_FLAG | LB_FLAG | RB_FLAG)
 #define GAMEPAD_COMBO_VMOUSE (LB_FLAG | RS_CLK_FLAG)
+
+#define CONTROLLER_TOUCHPAD_SECONDARY_CORNER 0.75f
+#define CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS 300u
+#define CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ (0.015f * 0.015f)
+#define CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_CHORD_MS 160u
+#define CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ (0.035f * 0.035f)
+
+enum {
+    CONTROLLER_TOUCHPAD_TAP_NONE = 0,
+    CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING,
+    CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD,
+    CONTROLLER_TOUCHPAD_TAP_TWO_PENDING,
+};
+
+enum {
+    CONTROLLER_TOUCHPAD_MOTION_NONE = 0,
+    CONTROLLER_TOUCHPAD_MOTION_SCROLL,
+    CONTROLLER_TOUCHPAD_MOTION_POINTER_0,
+    CONTROLLER_TOUCHPAD_MOTION_POINTER_1,
+};
+
+#define CONTROLLER_TOUCHPAD_TRACKED_FINGERS 2
+
+typedef struct controller_touchpad_finger_t {
+    float x, y;
+    float down_x, down_y;
+    uint32_t down_timestamp;
+} controller_touchpad_finger_t;
+
+struct session_input_controller_touchpad_t {
+    controller_touchpad_finger_t fingers[CONTROLLER_TOUCHPAD_TRACKED_FINGERS];
+    uint8_t active_fingers;
+    float motion_remainder_x, motion_remainder_y;
+    int8_t physical_mouse_button;
+    uint8_t motion_state;
+    uint8_t tap_state;
+};
 
 static bool quit_combo_pressed = false;
 static bool vmouse_combo_pressed = false;
@@ -26,7 +63,58 @@ static bool sensor_state_needs_update(const app_gamepad_sensor_state_t *state, u
 
 static bool vmouse_intercepted(stream_input_t *input, const app_gamepad_state_t *gamepad);
 
-static bool filter_deadzone_2axis(stream_input_t *input, short *x, short *y);
+static void filter_deadzone_2axis(const stream_input_t *input, short *x, short *y);
+
+static session_input_controller_touchpad_t *controller_touchpad_state(
+        stream_input_t *input, const app_gamepad_state_t *gamepad);
+
+static void controller_touchpad_reset_state(session_input_controller_touchpad_t *state);
+
+static bool controller_has_touchpad(const app_gamepad_state_t *gamepad);
+
+static void stream_input_send_gamepad_arrive(stream_input_t *input, app_gamepad_state_t *gamepad,
+                                              bool has_touchpad, uint16_t active_mask);
+
+static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state);
+
+static bool controller_touchpad_lower_right_press(const session_input_controller_touchpad_t *state);
+
+static bool controller_touchpad_finger_exceeded_tap_slop(
+        const controller_touchpad_finger_t *finger, float threshold_squared);
+
+static void controller_touchpad_end_tap(session_input_controller_touchpad_t *state);
+
+static void controller_touchpad_send_mouse_click(int mouse_button);
+
+static short controller_touchpad_take_delta(float *remainder);
+
+void stream_input_controller_touchpad_mouse_init(stream_input_t *input) {
+    if (input->controller_touchpads != NULL ||
+        input->controller_touchpad_mode != CONTROLLER_TOUCHPAD_MODE_MOUSE) {
+        return;
+    }
+
+    short count = app_input_get_max_gamepads(input->input);
+    if (count <= 0) {
+        return;
+    }
+
+    input->controller_touchpads = SDL_calloc((size_t) count, sizeof(*input->controller_touchpads));
+    if (input->controller_touchpads != NULL) {
+        input->controller_touchpad_count = count;
+    }
+}
+
+void stream_input_controller_touchpad_mouse_deinit(stream_input_t *input) {
+    if (input->controller_touchpads != NULL) {
+        for (short i = 0; i < input->controller_touchpad_count; ++i) {
+            controller_touchpad_reset_state(&input->controller_touchpads[i]);
+        }
+        SDL_free(input->controller_touchpads);
+        input->controller_touchpads = NULL;
+    }
+    input->controller_touchpad_count = 0;
+}
 
 void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButtonEvent *event) {
     app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
@@ -36,16 +124,16 @@ void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButt
     int button = 0;
     switch (event->button) {
         case SDL_CONTROLLER_BUTTON_A:
-            button = app_configuration->swap_abxy ? B_FLAG : A_FLAG;
+            button = input->swap_abxy ? B_FLAG : A_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_B:
-            button = app_configuration->swap_abxy ? A_FLAG : B_FLAG;
+            button = input->swap_abxy ? A_FLAG : B_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_Y:
-            button = app_configuration->swap_abxy ? X_FLAG : Y_FLAG;
+            button = input->swap_abxy ? X_FLAG : Y_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_X:
-            button = app_configuration->swap_abxy ? Y_FLAG : X_FLAG;
+            button = input->swap_abxy ? Y_FLAG : X_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_DPAD_UP:
             button = UP_FLAG;
@@ -82,7 +170,51 @@ void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButt
             button = RB_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_TOUCHPAD:
-            button = TOUCHPAD_FLAG;
+            switch (input->controller_touchpad_mode) {
+                case CONTROLLER_TOUCHPAD_MODE_DISABLED:
+                    return;
+                case CONTROLLER_TOUCHPAD_MODE_MOUSE: {
+                    if (input->view_only) {
+                        return;
+                    }
+
+                    session_input_controller_touchpad_t *state =
+                            controller_touchpad_state(input, gamepad);
+                    int mouse_button = 0;
+                    if (event->type == SDL_CONTROLLERBUTTONDOWN) {
+                        if (state != NULL) {
+                            // A physical click always wins over a tap gesture or drag.
+                            controller_touchpad_end_tap(state);
+                        }
+
+                        mouse_button = input->controller_touchpad_press_button;
+                        if (state != NULL && controller_touchpad_lower_right_press(state)) {
+                            mouse_button = input->controller_touchpad_secondary_button;
+                        }
+                        if (state != NULL) {
+                            // 0 means not pressed; -1 means physically pressed with no mapping.
+                            state->physical_mouse_button = (int8_t) (mouse_button != 0 ? mouse_button : -1);
+                        }
+                    } else if (state != NULL) {
+                        mouse_button = state->physical_mouse_button > 0 ? state->physical_mouse_button : 0;
+                        state->physical_mouse_button = 0;
+                    } else {
+                        mouse_button = input->controller_touchpad_press_button;
+                    }
+
+                    if (mouse_button != 0) {
+                        LiSendMouseButtonEvent(event->type == SDL_CONTROLLERBUTTONDOWN ?
+                                               BUTTON_ACTION_PRESS : BUTTON_ACTION_RELEASE,
+                                               mouse_button);
+                    }
+                    return;
+                }
+                case CONTROLLER_TOUCHPAD_MODE_NATIVE:
+                    button = TOUCHPAD_FLAG;
+                    break;
+                default:
+                    return;
+            }
             break;
         case SDL_CONTROLLER_BUTTON_MISC1:
             button = MISC_FLAG;
@@ -142,9 +274,20 @@ void stream_input_handle_caxis(stream_input_t *input, const SDL_ControllerAxisEv
     if (gamepad == NULL) {
         return;
     }
+
+    const char previous_left_trigger = gamepad->leftTrigger;
+    const char previous_right_trigger = gamepad->rightTrigger;
+    const short previous_left_stick_x = gamepad->leftStickX;
+    const short previous_left_stick_y = gamepad->leftStickY;
+    const short previous_right_stick_x = gamepad->rightStickX;
+    const short previous_right_stick_y = gamepad->rightStickY;
+
+    short *deadzone_x = NULL, *deadzone_y = NULL;
     switch (event->axis) {
         case SDL_CONTROLLER_AXIS_LEFTX: {
             gamepad->leftStickX = SDL_max(event->value, -32767);
+            deadzone_x = &gamepad->leftStickX;
+            deadzone_y = &gamepad->leftStickY;
             break;
         }
         case SDL_CONTROLLER_AXIS_LEFTY: {
@@ -154,14 +297,20 @@ void stream_input_handle_caxis(stream_input_t *input, const SDL_ControllerAxisEv
             // wrap around to be negative again. Avoid that by
             // capping the value at 32767.
             gamepad->leftStickY = (short) -SDL_max(event->value, (short) -32767);
+            deadzone_x = &gamepad->leftStickX;
+            deadzone_y = &gamepad->leftStickY;
             break;
         }
         case SDL_CONTROLLER_AXIS_RIGHTX: {
             gamepad->rightStickX = SDL_max(event->value, -32767);
+            deadzone_x = &gamepad->rightStickX;
+            deadzone_y = &gamepad->rightStickY;
             break;
         }
         case SDL_CONTROLLER_AXIS_RIGHTY: {
             gamepad->rightStickY = (short) -SDL_max(event->value, (short) -32767);
+            deadzone_x = &gamepad->rightStickX;
+            deadzone_y = &gamepad->rightStickY;
             break;
         }
         case SDL_CONTROLLER_AXIS_TRIGGERLEFT: {
@@ -179,8 +328,18 @@ void stream_input_handle_caxis(stream_input_t *input, const SDL_ControllerAxisEv
         return;
     }
 
-    filter_deadzone_2axis(input, &gamepad->leftStickX, &gamepad->leftStickY);
-    filter_deadzone_2axis(input, &gamepad->rightStickX, &gamepad->rightStickY);
+    if (deadzone_x != NULL) {
+        filter_deadzone_2axis(input, deadzone_x, deadzone_y);
+    }
+
+    if (gamepad->leftTrigger == previous_left_trigger &&
+        gamepad->rightTrigger == previous_right_trigger &&
+        gamepad->leftStickX == previous_left_stick_x &&
+        gamepad->leftStickY == previous_left_stick_y &&
+        gamepad->rightStickX == previous_right_stick_x &&
+        gamepad->rightStickY == previous_right_stick_y) {
+        return;
+    }
 
     if (vmouse_intercepted(input, gamepad)) {
         vmouse_set_vector(&input->vmouse, gamepad->rightStickX, gamepad->rightStickY);
@@ -196,11 +355,12 @@ void stream_input_handle_caxis(stream_input_t *input, const SDL_ControllerAxisEv
 }
 
 void stream_input_handle_csensor(stream_input_t *input, const SDL_ControllerSensorEvent *event) {
-    app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
-    if (gamepad == NULL) {
+    if (input->view_only) {
         return;
     }
-    if (input->view_only) {
+
+    app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
+    if (gamepad == NULL) {
         return;
     }
     switch (event->sensor) {
@@ -232,53 +392,311 @@ void stream_input_handle_csensor(stream_input_t *input, const SDL_ControllerSens
 }
 
 void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTouchpadEvent *event) {
+    if (event->touchpad != 0 || input->view_only) {
+        return;
+    }
+
+#if TARGET_WEBOS
+    if (input->controller_touchpad_webos_touchscreen) {
+        stream_input_controller_touchpad_compat_observe(input, event);
+    }
+#endif
+
+    if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_DISABLED) {
+        return;
+    }
+
     app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
     if (gamepad == NULL) {
         return;
     }
-    if (input->view_only) {
+
+    if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE) {
+        uint8_t native_event_type =
+                event->type == SDL_CONTROLLERTOUCHPADDOWN ? LI_TOUCH_EVENT_DOWN :
+                event->type == SDL_CONTROLLERTOUCHPADUP ? LI_TOUCH_EVENT_UP :
+                                                          LI_TOUCH_EVENT_MOVE;
+        LiSendControllerTouchEvent(gamepad->gs_id, native_event_type, event->finger,
+                                   event->x, event->y, event->pressure);
         return;
     }
-    if (event->touchpad != 0) {
+
+    session_input_controller_touchpad_t *state = controller_touchpad_state(input, gamepad);
+    if (state == NULL) {
         return;
     }
-    uint8_t event_type;
-    switch (event->type) {
-        case SDL_CONTROLLERTOUCHPADUP: {
-            event_type = LI_TOUCH_EVENT_UP;
-            break;
+
+    controller_touchpad_finger_t *finger = NULL;
+    bool was_active = false;
+    float finger_dx = 0.0f, finger_dy = 0.0f;
+    if (event->finger >= 0 && event->finger < CONTROLLER_TOUCHPAD_TRACKED_FINGERS) {
+        uint8_t finger_bit = (uint8_t) (1u << event->finger);
+        finger = &state->fingers[event->finger];
+        was_active = (state->active_fingers & finger_bit) != 0;
+        if (was_active && event->type == SDL_CONTROLLERTOUCHPADMOTION) {
+            finger_dx = event->x - finger->x;
+            finger_dy = event->y - finger->y;
         }
-        case SDL_CONTROLLERTOUCHPADDOWN: {
-            event_type = LI_TOUCH_EVENT_DOWN;
-            break;
+
+        if (!was_active && event->type != SDL_CONTROLLERTOUCHPADUP) {
+            finger->down_x = event->x;
+            finger->down_y = event->y;
+            finger->down_timestamp = event->timestamp;
         }
-        case SDL_CONTROLLERTOUCHPADMOTION: {
-            event_type = LI_TOUCH_EVENT_MOVE;
-            break;
+        finger->x = event->x;
+        finger->y = event->y;
+
+        if (was_active && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING &&
+            controller_touchpad_finger_exceeded_tap_slop(
+                    finger, CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
+            bool hold_elapsed = event->type == SDL_CONTROLLERTOUCHPADMOTION &&
+                                SDL_TICKS_PASSED(event->timestamp,
+                                                 finger->down_timestamp + CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS);
+            if (hold_elapsed) {
+                state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD;
+                LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
+            } else {
+                controller_touchpad_end_tap(state);
+            }
         }
-        default: {
+
+        if (was_active && state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING &&
+            controller_touchpad_finger_exceeded_tap_slop(
+                    finger, CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ)) {
+            controller_touchpad_end_tap(state);
+        }
+
+        if (event->type == SDL_CONTROLLERTOUCHPADUP) {
+            state->active_fingers &= (uint8_t) ~finger_bit;
+        } else {
+            state->active_fingers |= finger_bit;
+        }
+    } else if (event->type == SDL_CONTROLLERTOUCHPADDOWN) {
+        controller_touchpad_end_tap(state);
+    }
+
+    bool two_fingers = state->active_fingers == 0x3u;
+    if (event->type == SDL_CONTROLLERTOUCHPADDOWN) {
+        if (two_fingers) {
+            controller_touchpad_end_tap(state);
+
+            // Don't delay scrolling/pointer motion for a two-finger tap when
+            // the configured secondary action cannot produce a click.
+            if (input->controller_touchpad_secondary_button != 0) {
+                uint32_t t0 = state->fingers[0].down_timestamp;
+                uint32_t t1 = state->fingers[1].down_timestamp;
+                uint32_t chord_delta = t0 >= t1 ? t0 - t1 : t1 - t0;
+                bool within_slop =
+                        !controller_touchpad_finger_exceeded_tap_slop(
+                                &state->fingers[0], CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ) &&
+                        !controller_touchpad_finger_exceeded_tap_slop(
+                                &state->fingers[1], CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ);
+                if (chord_delta <= CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_CHORD_MS && within_slop) {
+                    state->tap_state = CONTROLLER_TOUCHPAD_TAP_TWO_PENDING;
+                }
+            }
+        } else if (state->active_fingers != 0 && input->controller_touchpad_tap_to_click &&
+                   finger != NULL && state->physical_mouse_button == 0) {
+            state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING;
+        }
+    } else if (event->type == SDL_CONTROLLERTOUCHPADUP) {
+        if (finger != NULL && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD) {
+            controller_touchpad_end_tap(state);
+        } else if (finger != NULL && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING) {
+            if (event->timestamp - finger->down_timestamp <= CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS) {
+                controller_touchpad_send_mouse_click(BUTTON_LEFT);
+            }
+            controller_touchpad_end_tap(state);
+        }
+
+        if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING && state->active_fingers == 0) {
+            uint32_t tap_start = state->fingers[0].down_timestamp < state->fingers[1].down_timestamp
+                                 ? state->fingers[0].down_timestamp
+                                 : state->fingers[1].down_timestamp;
+            if (event->timestamp - tap_start <= CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS) {
+                controller_touchpad_send_mouse_click(input->controller_touchpad_secondary_button);
+            }
+            controller_touchpad_end_tap(state);
+        }
+    }
+
+    // Keep pointer/scroll motion quiet until a two-finger tap either completes
+    // or exceeds its movement threshold.
+    if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING && state->active_fingers != 0) {
+        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        return;
+    }
+
+    if (input->controller_touchpad_two_finger_scroll && two_fingers) {
+        if (state->motion_state != CONTROLLER_TOUCHPAD_MOTION_SCROLL ||
+            event->type != SDL_CONTROLLERTOUCHPADMOTION) {
+            state->motion_state = CONTROLLER_TOUCHPAD_MOTION_SCROLL;
+            state->motion_remainder_x = 0.0f;
+            state->motion_remainder_y = 0.0f;
             return;
         }
-    }
-    LiSendControllerTouchEvent(gamepad->gs_id, event_type, event->finger, event->x, event->y, event->pressure);
-}
 
-void stream_input_handle_cdevice(stream_input_t *input, const SDL_ControllerDeviceEvent *event) {
-    app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
-    if (gamepad == NULL) {
+        state->motion_remainder_x += finger_dx * 0.5f * input->controller_touchpad_scroll_scale;
+        state->motion_remainder_y += finger_dy * 0.5f * input->controller_touchpad_scroll_scale;
+
+        short scroll_x = controller_touchpad_take_delta(&state->motion_remainder_x);
+        short scroll_y = controller_touchpad_take_delta(&state->motion_remainder_y);
+        if (scroll_y != 0) {
+            LiSendHighResScrollEvent(scroll_y);
+        }
+        if (scroll_x != 0) {
+            LiSendHighResHScrollEvent(scroll_x);
+        }
         return;
     }
+
+    if (state->motion_state == CONTROLLER_TOUCHPAD_MOTION_SCROLL) {
+        // Keep the pointer frozen for the entire two-finger scroll gesture.
+        // Touchpads report finger-up events independently, so without this
+        // latch the last finger would immediately become a pointer and move
+        // the cursor while the user is finishing the scroll gesture.
+        if (state->active_fingers != 0) {
+            return;
+        }
+
+        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        state->motion_remainder_x = 0.0f;
+        state->motion_remainder_y = 0.0f;
+        return;
+    }
+
+    int primary_finger = controller_touchpad_primary_finger(state);
+    if (primary_finger < 0) {
+        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        return;
+    }
+
+    uint8_t pointer_state = (uint8_t) (CONTROLLER_TOUCHPAD_MOTION_POINTER_0 + primary_finger);
+    if (state->motion_state != pointer_state || event->type != SDL_CONTROLLERTOUCHPADMOTION) {
+        state->motion_state = pointer_state;
+        state->motion_remainder_x = 0.0f;
+        state->motion_remainder_y = 0.0f;
+        return;
+    }
+
+    if (event->finger != primary_finger) {
+        return;
+    }
+
+    state->motion_remainder_x += finger_dx * input->controller_touchpad_mouse_scale_x;
+    state->motion_remainder_y += finger_dy * input->controller_touchpad_mouse_scale_y;
+
+    short dx = controller_touchpad_take_delta(&state->motion_remainder_x);
+    short dy = controller_touchpad_take_delta(&state->motion_remainder_y);
+    if (dx != 0 || dy != 0) {
+        LiSendMouseMoveEvent(dx, dy);
+    }
+}
+
+void stream_input_flush_controller_touchpad_tap_hold(stream_input_t *input) {
+    uint32_t timestamp = SDL_GetTicks();
+    for (short i = 0; i < input->controller_touchpad_count; ++i) {
+        session_input_controller_touchpad_t *state = &input->controller_touchpads[i];
+        if (state->tap_state != CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING) {
+            continue;
+        }
+        int primary_finger = controller_touchpad_primary_finger(state);
+        if (primary_finger < 0) {
+            controller_touchpad_end_tap(state);
+            continue;
+        }
+
+        const controller_touchpad_finger_t *finger = &state->fingers[primary_finger];
+        if (controller_touchpad_finger_exceeded_tap_slop(
+                    finger, CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
+            controller_touchpad_end_tap(state);
+            continue;
+        }
+
+        if (SDL_TICKS_PASSED(
+                    timestamp,
+                    finger->down_timestamp + CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS)) {
+            state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD;
+            LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
+        }
+    }
+}
+
+
+void stream_input_sync_gamepads(stream_input_t *input) {
     if (input->view_only) {
         return;
     }
-    stream_input_send_gamepad_arrive(input, gamepad);
+
+    uint16_t active_mask = (uint16_t) app_input_gamepads_mask(input->input);
+    uint16_t removed_mask = input->announced_gamepad_mask & (uint16_t) ~active_mask;
+
+    // app_input_t has already discarded removed controller state by the time
+    // this runs. Clear local touchpad state immediately, then notify Limelight
+    // when input forwarding is enabled.
+    for (int controller_id = 0; removed_mask != 0; ++controller_id, removed_mask >>= 1u) {
+        if ((removed_mask & 1u) == 0) {
+            continue;
+        }
+        if (input->controller_touchpads != NULL && controller_id < input->controller_touchpad_count) {
+            controller_touchpad_reset_state(&input->controller_touchpads[controller_id]);
+        }
+        LiSendMultiControllerEvent((short) controller_id, (short) active_mask,
+                                   0, 0, 0, 0, 0, 0, 0);
+    }
+    input->announced_gamepad_mask &= active_mask;
+#if TARGET_WEBOS
+    input->touchpad_gamepad_mask &= active_mask;
+#endif
+
+    uint16_t new_mask = active_mask & (uint16_t) ~input->announced_gamepad_mask;
+    if (new_mask != 0) {
+        int max_gamepads = app_input_get_max_gamepads(input->input);
+        bool query_touchpad = input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE;
+#if TARGET_WEBOS
+        query_touchpad = query_touchpad || input->controller_touchpad_webos_touchscreen;
+#endif
+
+        // Discover additions from app_input_t's authoritative active mask rather
+        // than relying on SDL_CONTROLLERDEVICEADDED ordering or device indices.
+        // This works for controllers attached before the stream and for hot-plug.
+        for (int i = 0; i < max_gamepads && new_mask != 0; ++i) {
+            app_gamepad_state_t *gamepad = app_input_gamepad_state_by_index(input->input, i);
+            if (gamepad == NULL || gamepad->gs_id < 0 || gamepad->gs_id >= 16) {
+                continue;
+            }
+
+            uint16_t controller_bit = (uint16_t) (1u << gamepad->gs_id);
+            if ((new_mask & controller_bit) == 0) {
+                continue;
+            }
+
+            bool has_touchpad = query_touchpad && controller_has_touchpad(gamepad);
+#if TARGET_WEBOS
+            if (has_touchpad) {
+                input->touchpad_gamepad_mask |= controller_bit;
+            }
+#endif
+            uint16_t arrival_mask = input->announced_gamepad_mask | controller_bit;
+            stream_input_send_gamepad_arrive(input, gamepad, has_touchpad, arrival_mask);
+            input->announced_gamepad_mask = arrival_mask;
+            new_mask &= (uint16_t) ~controller_bit;
+        }
+    }
+#if TARGET_WEBOS
+    if (input->controller_touchpad_webos_touchscreen) {
+        stream_input_controller_touchpad_compat_set_present(input, input->touchpad_gamepad_mask != 0);
+    }
+#endif
 }
 
-void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_state_t *gamepad) {
+static void stream_input_send_gamepad_arrive(stream_input_t *input, app_gamepad_state_t *gamepad,
+                                              bool has_touchpad, uint16_t active_mask) {
     uint8_t type = LI_CTYPE_XBOX;
     uint16_t capabilities = LI_CCAP_ANALOG_TRIGGERS;
     commons_log_info("Input", "Controller %d arrived. Name: %s", gamepad->gs_id,
                      SDL_GameControllerName(gamepad->controller));
+
     switch (SDL_GameControllerGetType(gamepad->controller)) {
 #if SDL_VERSION_ATLEAST(2, 24, 0)
         case SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_JOYCON_PAIR:
@@ -290,20 +708,19 @@ void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_s
             capabilities &= ~LI_CCAP_ANALOG_TRIGGERS;
             break;
         }
-        case SDL_CONTROLLER_TYPE_PS3: {
-            type = LI_CTYPE_PS;
-            break;
-        }
+        case SDL_CONTROLLER_TYPE_PS3:
         case SDL_CONTROLLER_TYPE_PS4:
         case SDL_CONTROLLER_TYPE_PS5: {
             type = LI_CTYPE_PS;
-            capabilities |= LI_CCAP_TOUCHPAD;
-            commons_log_info("Input", "  controller capability: touchpad");
             break;
         }
         default: {
             break;
         }
+    }
+    if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE && has_touchpad) {
+        capabilities |= LI_CCAP_TOUCHPAD;
+        commons_log_info("Input", "  controller capability: touchpad");
     }
 #if SDL_VERSION_ATLEAST(2, 0, 18)
     if (SDL_GameControllerHasRumble(gamepad->controller)) {
@@ -334,7 +751,92 @@ void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_s
         commons_log_info("Input", "  controller capability: RGB LED");
     }
 #endif
-    LiSendControllerArrivalEvent(gamepad->gs_id, input->input->activeGamepadMask, type, 0xFFFFFFFF, capabilities);
+    uint32_t supported_buttons = 0xFFFFFFFFu;
+    if (input->controller_touchpad_mode != CONTROLLER_TOUCHPAD_MODE_NATIVE || !has_touchpad) {
+        supported_buttons &= ~(uint32_t) TOUCHPAD_FLAG;
+    }
+    LiSendControllerArrivalEvent(gamepad->gs_id, active_mask, type,
+                                 supported_buttons, capabilities);
+}
+
+static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state) {
+    return state->active_fingers & 1u ? 0 : (state->active_fingers & 2u ? 1 : -1);
+}
+
+static bool controller_touchpad_lower_right_press(const session_input_controller_touchpad_t *state) {
+    int primary_finger = controller_touchpad_primary_finger(state);
+    if (primary_finger < 0) {
+        return false;
+    }
+
+    const controller_touchpad_finger_t *finger = &state->fingers[primary_finger];
+    return finger->x >= CONTROLLER_TOUCHPAD_SECONDARY_CORNER &&
+           finger->y >= CONTROLLER_TOUCHPAD_SECONDARY_CORNER;
+}
+
+static bool controller_touchpad_finger_exceeded_tap_slop(
+        const controller_touchpad_finger_t *finger, float threshold_squared) {
+    float dx = finger->x - finger->down_x;
+    float dy = finger->y - finger->down_y;
+    return dx * dx + dy * dy > threshold_squared;
+}
+
+static void controller_touchpad_end_tap(session_input_controller_touchpad_t *state) {
+    if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD) {
+        LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
+    }
+    state->tap_state = CONTROLLER_TOUCHPAD_TAP_NONE;
+}
+
+static void controller_touchpad_send_mouse_click(int mouse_button) {
+    if (mouse_button == 0) {
+        return;
+    }
+    LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, mouse_button);
+    LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, mouse_button);
+}
+
+static short controller_touchpad_take_delta(float *remainder) {
+    // SDL touch coordinates are normalized, so scaled per-event deltas stay
+    // comfortably within Limelight's signed 16-bit mouse/scroll range.
+    short result = (short) *remainder;
+    *remainder -= (float) result;
+    return result;
+}
+
+static session_input_controller_touchpad_t *controller_touchpad_state(
+        stream_input_t *input, const app_gamepad_state_t *gamepad) {
+    if (input->controller_touchpads == NULL || gamepad->gs_id < 0 ||
+        gamepad->gs_id >= input->controller_touchpad_count) {
+        return NULL;
+    }
+    return &input->controller_touchpads[gamepad->gs_id];
+}
+
+static void controller_touchpad_reset_state(session_input_controller_touchpad_t *state) {
+    controller_touchpad_end_tap(state);
+    if (state->physical_mouse_button > 0) {
+        LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, state->physical_mouse_button);
+    }
+    SDL_memset(state, 0, sizeof(*state));
+}
+
+static bool controller_has_touchpad(const app_gamepad_state_t *gamepad) {
+    if (gamepad->controller == NULL) {
+        return false;
+    }
+
+    SDL_GameControllerType controller_type = SDL_GameControllerGetType(gamepad->controller);
+    if (controller_type == SDL_CONTROLLER_TYPE_PS4 ||
+        controller_type == SDL_CONTROLLER_TYPE_PS5) {
+        return true;
+    }
+
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    return SDL_GameControllerGetNumTouchpads(gamepad->controller) > 0;
+#else
+    return false;
+#endif
 }
 
 static void release_buttons(stream_input_t *input, app_gamepad_state_t *gamepad) {
@@ -376,13 +878,10 @@ static bool vmouse_intercepted(stream_input_t *input, const app_gamepad_state_t 
            gamepad->rightTrigger != 0;
 }
 
-static bool filter_deadzone_2axis(stream_input_t *input, short *x, short *y) {
+static void filter_deadzone_2axis(const stream_input_t *input, short *x, short *y) {
     uint32_t magnitude_pow2 = (uint32_t) (*x) * (*x) + (uint32_t) (*y) * (*y);
-    uint32_t threshold_sqrt = 32768 * input->stick_deadzone / 100;
-    if (magnitude_pow2 < threshold_sqrt * threshold_sqrt) {
+    if (magnitude_pow2 < input->stick_deadzone_squared) {
         *x = 0;
         *y = 0;
-        return true;
     }
-    return false;
 }

--- a/src/app/stream/input/session_input.c
+++ b/src/app/stream/input/session_input.c
@@ -18,27 +18,71 @@
 
 #include "session_input.h"
 #include "stream/session.h"
-#include "stream/session_priv.h"
-#include "session_evmouse.h"
+
+#define CONTROLLER_TOUCHPAD_MOUSE_SCALE_X_PERCENT 16.0f
+#define CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT 9.0f
+#define CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE 600.0f
+
+static uint8_t controller_touchpad_mouse_button(int press) {
+    static const uint8_t buttons[] = {0, BUTTON_LEFT, BUTTON_RIGHT, BUTTON_MIDDLE};
+    return (unsigned int) press < sizeof(buttons) / sizeof(buttons[0]) ? buttons[press] : 0;
+}
+
+#if FEATURE_INPUT_EVMOUSE
+static bool session_input_uses_evmouse(const stream_input_t *input) {
+    return !input->view_only && input->no_sdl_mouse;
+}
+#endif
 
 void session_input_init(stream_input_t *input, session_t *session, app_input_t *app_input,
                         const session_config_t *config) {
     input->session = session;
     input->input = app_input;
+    input->started = false;
     input->view_only = config->view_only;
-    input->stick_deadzone = config->stick_deadzone;
     input->no_sdl_mouse = config->hardware_mouse;
+    input->swap_abxy = config->swap_abxy;
+    input->controller_touchpad_mode = (uint8_t) config->controller_touchpad_mode;
+    input->controller_touchpad_press_button =
+            controller_touchpad_mouse_button((uint8_t) config->controller_touchpad_press);
+    input->controller_touchpad_secondary_button =
+            controller_touchpad_mouse_button((uint8_t) config->controller_touchpad_secondary_click);
+    input->controller_touchpad_tap_to_click = config->controller_touchpad_tap_to_click;
+    input->controller_touchpad_two_finger_scroll = config->controller_touchpad_two_finger_scroll;
+    input->controller_touchpad_mouse_scale_x = CONTROLLER_TOUCHPAD_MOUSE_SCALE_X_PERCENT *
+                                               (float) (uint8_t) config->controller_touchpad_sensitivity;
+    input->controller_touchpad_mouse_scale_y = CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT *
+                                               (float) (uint8_t) config->controller_touchpad_sensitivity;
+    input->controller_touchpad_scroll_scale = config->controller_touchpad_invert_two_finger_scroll
+                                              ? CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE
+                                              : -CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE;
+    input->announced_gamepad_mask = 0;
+#if TARGET_WEBOS
+    input->touchpad_gamepad_mask = 0;
+#endif
+    uint32_t stick_deadzone = 32768u * (uint32_t) config->stick_deadzone / 100u;
+    input->stick_deadzone_squared = stick_deadzone * stick_deadzone;
+#if TARGET_WEBOS
+    input->controller_touchpad_webos_touchscreen = config->controller_touchpad_webos_touchscreen;
+    input->controller_touchpad_compat = NULL;
+#endif
+
+    input->controller_touchpads = NULL;
+    input->controller_touchpad_count = 0;
 #if FEATURE_INPUT_EVMOUSE
-    if (!config->view_only && config->hardware_mouse) {
+    if (session_input_uses_evmouse(input)) {
         session_evmouse_init(&input->evmouse, session);
     }
 #endif
 }
 
 void session_input_deinit(stream_input_t *input) {
+#if TARGET_WEBOS
+    stream_input_controller_touchpad_compat_deinit(input);
+#endif
+    stream_input_controller_touchpad_mouse_deinit(input);
 #if FEATURE_INPUT_EVMOUSE
-    const session_config_t *config = &input->session->config;
-    if (!config->view_only && config->hardware_mouse) {
+    if (session_input_uses_evmouse(input)) {
         session_evmouse_deinit(&input->evmouse);
     }
 #endif
@@ -46,8 +90,7 @@ void session_input_deinit(stream_input_t *input) {
 
 void session_input_interrupt(stream_input_t *input) {
 #if FEATURE_INPUT_EVMOUSE
-    const session_config_t *config = &input->session->config;
-    if (!config->view_only && config->hardware_mouse) {
+    if (session_input_uses_evmouse(input)) {
         session_evmouse_interrupt(&input->evmouse);
     }
 #endif
@@ -55,23 +98,31 @@ void session_input_interrupt(stream_input_t *input) {
 
 void session_input_started(stream_input_t *input) {
     input->started = true;
-    for (int i = 0, j = app_input_get_max_gamepads(input->input); i < j; ++i) {
-        app_gamepad_state_t *gamepad = app_input_gamepad_state_by_index(input->input, i);
-        if (gamepad == NULL) {
-            continue;
-        }
-        stream_input_send_gamepad_arrive(input, gamepad);
+    input->announced_gamepad_mask = 0;
+#if TARGET_WEBOS
+    input->touchpad_gamepad_mask = 0;
+#endif
+    if (!input->view_only) {
+        stream_input_controller_touchpad_mouse_init(input);
+        stream_input_sync_gamepads(input);
     }
 }
 
 void session_input_stopped(stream_input_t *input) {
     input->started = false;
+    input->announced_gamepad_mask = 0;
+#if TARGET_WEBOS
+    input->touchpad_gamepad_mask = 0;
+#endif
+    stream_input_controller_touchpad_mouse_deinit(input);
+#if TARGET_WEBOS
+    stream_input_controller_touchpad_compat_deinit(input);
+#endif
 }
 
 void session_input_screen_keyboard_opened(stream_input_t *input) {
 #if FEATURE_INPUT_EVMOUSE
-    const session_config_t *config = &input->session->config;
-    if (config->hardware_mouse) {
+    if (session_input_uses_evmouse(input)) {
         session_evmouse_disable(&input->evmouse);
     }
 #endif
@@ -79,8 +130,7 @@ void session_input_screen_keyboard_opened(stream_input_t *input) {
 
 void session_input_screen_keyboard_closed(stream_input_t *input) {
 #if FEATURE_INPUT_EVMOUSE
-    const session_config_t *config = &input->session->config;
-    if (config->hardware_mouse) {
+    if (session_input_uses_evmouse(input)) {
         session_evmouse_enable(&input->evmouse);
     }
 #endif

--- a/src/app/stream/input/session_input.h
+++ b/src/app/stream/input/session_input.h
@@ -28,13 +28,40 @@ typedef struct session_input_vmouse_t {
     SDL_TimerID timer_id;
 } session_input_vmouse_t;
 
+typedef struct session_input_controller_touchpad_t session_input_controller_touchpad_t;
+
+#if TARGET_WEBOS
+typedef struct session_input_controller_touchpad_compat_t session_input_controller_touchpad_compat_t;
+#endif
+
 typedef struct stream_input_t {
     session_t *session;
     app_input_t *input;
     bool started;
     bool view_only, no_sdl_mouse;
-    uint8_t stick_deadzone;
+    bool swap_abxy;
+    uint8_t controller_touchpad_mode;
+    uint8_t controller_touchpad_press_button;
+    uint8_t controller_touchpad_secondary_button;
+    bool controller_touchpad_tap_to_click;
+    bool controller_touchpad_two_finger_scroll;
+#if TARGET_WEBOS
+    bool controller_touchpad_webos_touchscreen;
+#endif
+    short controller_touchpad_count;
+    uint16_t announced_gamepad_mask;
+#if TARGET_WEBOS
+    uint16_t touchpad_gamepad_mask;
+#endif
+    uint32_t stick_deadzone_squared;
+    float controller_touchpad_mouse_scale_x;
+    float controller_touchpad_mouse_scale_y;
+    float controller_touchpad_scroll_scale;
     session_input_vmouse_t vmouse;
+    session_input_controller_touchpad_t *controller_touchpads;
+#if TARGET_WEBOS
+    session_input_controller_touchpad_compat_t *controller_touchpad_compat;
+#endif
 #if FEATURE_INPUT_EVMOUSE
     session_evmouse_t evmouse;
 #endif
@@ -51,11 +78,28 @@ void session_input_started(stream_input_t *input);
 
 void session_input_stopped(stream_input_t *input);
 
+void stream_input_controller_touchpad_mouse_init(stream_input_t *input);
+
+void stream_input_controller_touchpad_mouse_deinit(stream_input_t *input);
+
+#if TARGET_WEBOS
+void stream_input_controller_touchpad_compat_deinit(stream_input_t *input);
+
+void stream_input_controller_touchpad_compat_set_present(stream_input_t *input, bool present);
+
+bool stream_input_controller_touchpad_compat_mouse_active(const stream_input_t *input, uint32_t timestamp);
+
+void stream_input_controller_touchpad_compat_observe(stream_input_t *input,
+                                                     const SDL_ControllerTouchpadEvent *event);
+
+void stream_input_flush_pending_touch(stream_input_t *input);
+#endif
+
 void session_input_screen_keyboard_opened(stream_input_t *input);
 
 void session_input_screen_keyboard_closed(stream_input_t *input);
 
-void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_state_t *gamepad);
+void stream_input_sync_gamepads(stream_input_t *input);
 
 void stream_input_handle_key(stream_input_t *input, const SDL_KeyboardEvent *event);
 
@@ -69,7 +113,7 @@ void stream_input_handle_csensor(stream_input_t *input, const SDL_ControllerSens
 
 void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTouchpadEvent *event);
 
-void stream_input_handle_cdevice(stream_input_t *input, const SDL_ControllerDeviceEvent *event);
+void stream_input_flush_controller_touchpad_tap_hold(stream_input_t *input);
 
 void stream_input_handle_mmotion(stream_input_t *input, const SDL_MouseMotionEvent *event, bool hw_mouse);
 
@@ -77,4 +121,4 @@ void stream_input_handle_mbutton(stream_input_t *input, const SDL_MouseButtonEve
 
 void stream_input_handle_mwheel(stream_input_t *input, const SDL_MouseWheelEvent *event);
 
-void stream_input_handle_touch(const stream_input_t *input, const SDL_TouchFingerEvent *event);
+void stream_input_handle_touch(stream_input_t *input, const SDL_TouchFingerEvent *event);

--- a/src/app/stream/input/session_mouse.c
+++ b/src/app/stream/input/session_mouse.c
@@ -8,8 +8,23 @@
 #include <Limelight.h>
 #include <SDL.h>
 
-void stream_input_handle_mbutton(stream_input_t *input, const SDL_MouseButtonEvent *event) {
+static bool stream_input_touch_mouse_suppressed(const stream_input_t *input, uint32_t which,
+                                                uint32_t timestamp) {
+#if TARGET_WEBOS
+    return which == SDL_TOUCH_MOUSEID &&
+           stream_input_controller_touchpad_compat_mouse_active(input, timestamp);
+#else
     (void) input;
+    (void) which;
+    (void) timestamp;
+    return false;
+#endif
+}
+
+void stream_input_handle_mbutton(stream_input_t *input, const SDL_MouseButtonEvent *event) {
+    if (stream_input_touch_mouse_suppressed(input, event->which, event->timestamp)) {
+        return;
+    }
     int button;
     switch (event->button) {
         case SDL_BUTTON_LEFT:
@@ -46,7 +61,9 @@ void stream_input_handle_mbutton(stream_input_t *input, const SDL_MouseButtonEve
 }
 
 void stream_input_handle_mwheel(stream_input_t *input, const SDL_MouseWheelEvent *event) {
-    (void) input;
+    if (stream_input_touch_mouse_suppressed(input, event->which, event->timestamp)) {
+        return;
+    }
     if (event->which == SDL_TOUCH_MOUSEID && LiGetHostFeatureFlags() & LI_FF_PEN_TOUCH_EVENTS) {
         // Don't send mouse events from touch devices if the host supports pen/touch events
         return;
@@ -61,6 +78,10 @@ void stream_input_handle_mwheel(stream_input_t *input, const SDL_MouseWheelEvent
 
 void stream_input_handle_mmotion(stream_input_t *input, const SDL_MouseMotionEvent *event, bool hw_mouse) {
     if (input->view_only) {
+        return;
+    }
+    if (!hw_mouse &&
+        stream_input_touch_mouse_suppressed(input, event->which, event->timestamp)) {
         return;
     }
     if (event->which == SDL_TOUCH_MOUSEID && LiGetHostFeatureFlags() & LI_FF_PEN_TOUCH_EVENTS) {

--- a/src/app/stream/input/session_touch.c
+++ b/src/app/stream/input/session_touch.c
@@ -1,9 +1,8 @@
 #include "stream/input/session_input.h"
 
-void stream_input_handle_touch(const stream_input_t *input, const SDL_TouchFingerEvent *event) {
-    if (input->view_only) {
-        return;
-    }
+#include <SDL_touch.h>
+
+static void stream_input_send_touch(const SDL_TouchFingerEvent *event) {
     uint8_t type;
     switch (event->type) {
         case SDL_FINGERDOWN:
@@ -19,4 +18,353 @@ void stream_input_handle_touch(const stream_input_t *input, const SDL_TouchFinge
             return;
     }
     LiSendTouchEvent(type, event->fingerId, event->x, event->y, event->pressure, 0, 0, 0);
+}
+
+#if TARGET_WEBOS
+#define CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES 8
+#define CONTROLLER_TOUCHPAD_COMPAT_EVENT_WINDOW_MS 50u
+
+enum {
+    CONTROLLER_TOUCHPAD_COMPAT_UNUSED = 0,
+    CONTROLLER_TOUCHPAD_COMPAT_PENDING,
+    CONTROLLER_TOUCHPAD_COMPAT_FORWARDED,
+    CONTROLLER_TOUCHPAD_COMPAT_SUPPRESSED,
+};
+
+enum {
+    CONTROLLER_TOUCHPAD_COMPAT_HAS_MOTION = 1u << 0,
+    CONTROLLER_TOUCHPAD_COMPAT_HAS_UP = 1u << 1,
+};
+
+typedef struct controller_touchpad_compat_sample_t {
+    float x, y, pressure;
+} controller_touchpad_compat_sample_t;
+
+typedef struct controller_touchpad_compat_candidate_t {
+    SDL_TouchID touch_id;
+    SDL_FingerID finger_id;
+    uint32_t down_timestamp;
+    controller_touchpad_compat_sample_t down, motion, up;
+    uint8_t state, buffered;
+} controller_touchpad_compat_candidate_t;
+
+struct session_input_controller_touchpad_compat_t {
+    bool controller_present;
+    bool last_down_valid;
+    bool has_pending;
+    bool has_suppressed;
+    uint32_t last_down_timestamp;
+    uint32_t suppress_until;
+    controller_touchpad_compat_candidate_t candidates[CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES];
+};
+
+static void controller_touchpad_compat_send_sample(uint8_t type, SDL_FingerID finger_id,
+                                                   const controller_touchpad_compat_sample_t *sample) {
+    LiSendTouchEvent(type, finger_id, sample->x, sample->y, sample->pressure, 0, 0, 0);
+}
+
+void stream_input_controller_touchpad_compat_deinit(stream_input_t *input) {
+    session_input_controller_touchpad_compat_t *compat = input->controller_touchpad_compat;
+    if (compat == NULL) {
+        return;
+    }
+
+    // A forwarded touchscreen contact already has a DOWN event on the host.
+    // Cancel it before discarding compatibility state to avoid a stuck touch.
+    for (int i = 0; i < CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES; ++i) {
+        controller_touchpad_compat_candidate_t *candidate = &compat->candidates[i];
+        if (candidate->state == CONTROLLER_TOUCHPAD_COMPAT_FORWARDED) {
+            LiSendTouchEvent(LI_TOUCH_EVENT_CANCEL, candidate->finger_id, 0, 0, 0, 0, 0, 0);
+        }
+    }
+
+    SDL_free(compat);
+    input->controller_touchpad_compat = NULL;
+}
+
+void stream_input_controller_touchpad_compat_set_present(stream_input_t *input, bool present) {
+    if (present && input->controller_touchpad_compat == NULL) {
+        input->controller_touchpad_compat = SDL_calloc(1, sizeof(*input->controller_touchpad_compat));
+    }
+    if (input->controller_touchpad_compat != NULL) {
+        input->controller_touchpad_compat->controller_present = present;
+    }
+}
+
+static uint32_t controller_touchpad_compat_timestamp_distance(uint32_t a, uint32_t b) {
+    uint32_t forward = a - b;
+    uint32_t backward = b - a;
+    return forward < backward ? forward : backward;
+}
+
+static bool controller_touchpad_compat_timestamp_matches(uint32_t a, uint32_t b) {
+    return controller_touchpad_compat_timestamp_distance(a, b) <=
+           CONTROLLER_TOUCHPAD_COMPAT_EVENT_WINDOW_MS;
+}
+
+static bool controller_touchpad_compat_event_queued(uint32_t timestamp) {
+    SDL_Event pending[16];
+    int count = SDL_PeepEvents(pending, (int) (sizeof(pending) / sizeof(pending[0])),
+                               SDL_PEEKEVENT, SDL_CONTROLLERTOUCHPADDOWN, SDL_CONTROLLERTOUCHPADUP);
+    for (int i = 0; i < count; ++i) {
+        if (pending[i].ctouchpad.touchpad == 0 &&
+            controller_touchpad_compat_timestamp_matches(pending[i].ctouchpad.timestamp, timestamp)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool controller_touchpad_compat_matches_recent_down(
+        const session_input_controller_touchpad_compat_t *compat, uint32_t timestamp) {
+    return compat->last_down_valid &&
+           controller_touchpad_compat_timestamp_matches(compat->last_down_timestamp, timestamp);
+}
+
+bool stream_input_controller_touchpad_compat_mouse_active(const stream_input_t *input,
+                                                          uint32_t timestamp) {
+    if (!input->controller_touchpad_webos_touchscreen) {
+        return true;
+    }
+
+    const session_input_controller_touchpad_compat_t *compat = input->controller_touchpad_compat;
+    if (compat == NULL) {
+        return false;
+    }
+
+    if (controller_touchpad_compat_matches_recent_down(compat, timestamp) ||
+        !SDL_TICKS_PASSED(timestamp, compat->suppress_until)) {
+        return true;
+    }
+
+    if (compat->has_suppressed) {
+        return true;
+    }
+
+    return compat->controller_present && controller_touchpad_compat_event_queued(timestamp);
+}
+
+static controller_touchpad_compat_candidate_t *controller_touchpad_compat_find_candidate(
+        session_input_controller_touchpad_compat_t *compat, SDL_TouchID touch_id, SDL_FingerID finger_id) {
+    for (int i = 0; i < CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES; ++i) {
+        controller_touchpad_compat_candidate_t *candidate = &compat->candidates[i];
+        if (candidate->state != CONTROLLER_TOUCHPAD_COMPAT_UNUSED &&
+            candidate->touch_id == touch_id && candidate->finger_id == finger_id) {
+            return candidate;
+        }
+    }
+    return NULL;
+}
+
+static controller_touchpad_compat_candidate_t *controller_touchpad_compat_alloc_candidate(
+        session_input_controller_touchpad_compat_t *compat) {
+    for (int i = 0; i < CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES; ++i) {
+        if (compat->candidates[i].state == CONTROLLER_TOUCHPAD_COMPAT_UNUSED) {
+            return &compat->candidates[i];
+        }
+    }
+    return NULL;
+}
+
+static void controller_touchpad_compat_update_activity(
+        session_input_controller_touchpad_compat_t *compat) {
+    compat->has_pending = false;
+    compat->has_suppressed = false;
+    for (int i = 0; i < CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES; ++i) {
+        switch (compat->candidates[i].state) {
+            case CONTROLLER_TOUCHPAD_COMPAT_PENDING:
+                compat->has_pending = true;
+                break;
+            case CONTROLLER_TOUCHPAD_COMPAT_SUPPRESSED:
+                compat->has_suppressed = true;
+                break;
+            default:
+                break;
+        }
+        if (compat->has_pending && compat->has_suppressed) {
+            return;
+        }
+    }
+}
+
+static bool controller_touchpad_compat_track_down(
+        session_input_controller_touchpad_compat_t *compat,
+        const SDL_TouchFingerEvent *event, bool suppressed) {
+    controller_touchpad_compat_candidate_t *candidate = controller_touchpad_compat_alloc_candidate(compat);
+    if (candidate == NULL) {
+        return false;
+    }
+
+    candidate->touch_id = event->touchId;
+    candidate->finger_id = event->fingerId;
+    candidate->down_timestamp = event->timestamp;
+    candidate->down = (controller_touchpad_compat_sample_t) {event->x, event->y, event->pressure};
+    candidate->state = suppressed ? CONTROLLER_TOUCHPAD_COMPAT_SUPPRESSED
+                                  : CONTROLLER_TOUCHPAD_COMPAT_PENDING;
+    candidate->buffered = 0;
+    if (suppressed) {
+        compat->has_suppressed = true;
+    } else {
+        compat->has_pending = true;
+    }
+    return true;
+}
+
+static void controller_touchpad_compat_flush_candidate(controller_touchpad_compat_candidate_t *candidate) {
+    controller_touchpad_compat_send_sample(LI_TOUCH_EVENT_DOWN, candidate->finger_id, &candidate->down);
+    candidate->state = CONTROLLER_TOUCHPAD_COMPAT_FORWARDED;
+
+    if (candidate->buffered & CONTROLLER_TOUCHPAD_COMPAT_HAS_MOTION) {
+        controller_touchpad_compat_send_sample(LI_TOUCH_EVENT_MOVE, candidate->finger_id, &candidate->motion);
+    }
+    if (candidate->buffered & CONTROLLER_TOUCHPAD_COMPAT_HAS_UP) {
+        controller_touchpad_compat_send_sample(LI_TOUCH_EVENT_UP, candidate->finger_id, &candidate->up);
+        candidate->state = CONTROLLER_TOUCHPAD_COMPAT_UNUSED;
+    }
+}
+
+void stream_input_controller_touchpad_compat_observe(stream_input_t *input,
+                                                     const SDL_ControllerTouchpadEvent *event) {
+    session_input_controller_touchpad_compat_t *compat = input->controller_touchpad_compat;
+    if (compat == NULL || event->touchpad != 0) {
+        return;
+    }
+
+    if (event->type == SDL_CONTROLLERTOUCHPADUP) {
+        compat->suppress_until = event->timestamp + CONTROLLER_TOUCHPAD_COMPAT_EVENT_WINDOW_MS;
+        return;
+    }
+    if (event->type != SDL_CONTROLLERTOUCHPADDOWN) {
+        return;
+    }
+
+    compat->last_down_valid = true;
+    compat->last_down_timestamp = event->timestamp;
+
+    controller_touchpad_compat_candidate_t *best = NULL;
+    uint32_t best_distance = CONTROLLER_TOUCHPAD_COMPAT_EVENT_WINDOW_MS + 1;
+    for (int i = 0; i < CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES; ++i) {
+        controller_touchpad_compat_candidate_t *candidate = &compat->candidates[i];
+        if (candidate->state != CONTROLLER_TOUCHPAD_COMPAT_PENDING &&
+            candidate->state != CONTROLLER_TOUCHPAD_COMPAT_FORWARDED) {
+            continue;
+        }
+
+        uint32_t distance = controller_touchpad_compat_timestamp_distance(
+                candidate->down_timestamp, event->timestamp);
+        if (distance <= CONTROLLER_TOUCHPAD_COMPAT_EVENT_WINDOW_MS && distance < best_distance) {
+            best = candidate;
+            best_distance = distance;
+        }
+    }
+
+    if (best == NULL) {
+        return;
+    }
+
+    if (best->state == CONTROLLER_TOUCHPAD_COMPAT_PENDING) {
+        best->state = (best->buffered & CONTROLLER_TOUCHPAD_COMPAT_HAS_UP)
+                      ? CONTROLLER_TOUCHPAD_COMPAT_UNUSED
+                      : CONTROLLER_TOUCHPAD_COMPAT_SUPPRESSED;
+        controller_touchpad_compat_update_activity(compat);
+        return;
+    }
+
+    LiSendTouchEvent(LI_TOUCH_EVENT_CANCEL, best->finger_id, 0, 0, 0, 0, 0, 0);
+    best->state = CONTROLLER_TOUCHPAD_COMPAT_SUPPRESSED;
+    compat->has_suppressed = true;
+}
+
+void stream_input_flush_pending_touch(stream_input_t *input) {
+    session_input_controller_touchpad_compat_t *compat = input->controller_touchpad_compat;
+    if (compat == NULL || !compat->has_pending) {
+        return;
+    }
+
+    uint32_t now = SDL_GetTicks();
+    compat->has_pending = false;
+    for (int i = 0; i < CONTROLLER_TOUCHPAD_COMPAT_TOUCH_CANDIDATES; ++i) {
+        controller_touchpad_compat_candidate_t *candidate = &compat->candidates[i];
+        if (candidate->state != CONTROLLER_TOUCHPAD_COMPAT_PENDING) {
+            continue;
+        }
+        if (SDL_TICKS_PASSED(now, candidate->down_timestamp +
+                                 CONTROLLER_TOUCHPAD_COMPAT_EVENT_WINDOW_MS)) {
+            controller_touchpad_compat_flush_candidate(candidate);
+        } else {
+            compat->has_pending = true;
+        }
+    }
+}
+#endif
+
+void stream_input_handle_touch(stream_input_t *input, const SDL_TouchFingerEvent *event) {
+#if TARGET_WEBOS
+    if (!input->controller_touchpad_webos_touchscreen) {
+        return;
+    }
+#endif
+
+    if (input->view_only) {
+        return;
+    }
+
+    SDL_TouchDeviceType touch_type = SDL_GetTouchDeviceType(event->touchId);
+    if (touch_type == SDL_TOUCH_DEVICE_INDIRECT_ABSOLUTE ||
+        touch_type == SDL_TOUCH_DEVICE_INDIRECT_RELATIVE) {
+        return;
+    }
+
+#if TARGET_WEBOS
+    session_input_controller_touchpad_compat_t *compat = input->controller_touchpad_compat;
+    controller_touchpad_compat_candidate_t *candidate = compat != NULL
+            ? controller_touchpad_compat_find_candidate(compat, event->touchId, event->fingerId)
+            : NULL;
+
+    if (event->type == SDL_FINGERDOWN) {
+        if (candidate != NULL) {
+            bool tracked_activity = candidate->state == CONTROLLER_TOUCHPAD_COMPAT_PENDING ||
+                                    candidate->state == CONTROLLER_TOUCHPAD_COMPAT_SUPPRESSED;
+            if (candidate->state == CONTROLLER_TOUCHPAD_COMPAT_FORWARDED) {
+                LiSendTouchEvent(LI_TOUCH_EVENT_CANCEL, candidate->finger_id, 0, 0, 0, 0, 0, 0);
+            }
+            candidate->state = CONTROLLER_TOUCHPAD_COMPAT_UNUSED;
+            if (tracked_activity) {
+                controller_touchpad_compat_update_activity(compat);
+            }
+        }
+
+        if (compat != NULL && compat->controller_present &&
+            controller_touchpad_compat_track_down(
+                    compat, event, controller_touchpad_compat_matches_recent_down(compat, event->timestamp))) {
+            return;
+        }
+    } else if (candidate != NULL) {
+        if (candidate->state == CONTROLLER_TOUCHPAD_COMPAT_SUPPRESSED) {
+            if (event->type == SDL_FINGERUP) {
+                candidate->state = CONTROLLER_TOUCHPAD_COMPAT_UNUSED;
+                controller_touchpad_compat_update_activity(compat);
+            }
+            return;
+        }
+        if (candidate->state == CONTROLLER_TOUCHPAD_COMPAT_PENDING) {
+            if (event->type == SDL_FINGERMOTION) {
+                candidate->motion = (controller_touchpad_compat_sample_t) {event->x, event->y, event->pressure};
+                candidate->buffered |= CONTROLLER_TOUCHPAD_COMPAT_HAS_MOTION;
+            } else if (event->type == SDL_FINGERUP) {
+                candidate->up = (controller_touchpad_compat_sample_t) {event->x, event->y, event->pressure};
+                candidate->buffered |= CONTROLLER_TOUCHPAD_COMPAT_HAS_UP;
+            }
+            return;
+        }
+    }
+#endif
+
+    stream_input_send_touch(event);
+
+#if TARGET_WEBOS
+    if (event->type == SDL_FINGERUP && candidate != NULL) {
+        candidate->state = CONTROLLER_TOUCHPAD_COMPAT_UNUSED;
+    }
+#endif
 }

--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -248,6 +248,15 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
                          const CONFIGURATION *app_config) {
     config->stream = app_config->stream;
     config->vmouse = app_config->virtual_mouse;
+    config->controller_touchpad_mode = app_config->controller_touchpad_mode;
+    config->controller_touchpad_sensitivity = app_config->controller_touchpad_sensitivity;
+    config->controller_touchpad_press = app_config->controller_touchpad_press;
+    config->controller_touchpad_secondary_click = app_config->controller_touchpad_secondary_click;
+    config->controller_touchpad_tap_to_click = app_config->controller_touchpad_tap_to_click;
+    config->controller_touchpad_two_finger_scroll = app_config->controller_touchpad_two_finger_scroll;
+    config->controller_touchpad_invert_two_finger_scroll = app_config->controller_touchpad_invert_two_finger_scroll;
+    config->controller_touchpad_webos_touchscreen = app_config->controller_touchpad_webos_touchscreen;
+    config->swap_abxy = app_config->swap_abxy;
     config->hardware_mouse = app_config->hardware_mouse;
     config->local_audio = app_config->localaudio;
     config->view_only = app_config->viewonly;

--- a/src/app/stream/session.h
+++ b/src/app/stream/session.h
@@ -60,6 +60,15 @@ typedef struct session_config_t {
     bool local_audio;
     bool hardware_mouse;
     bool vmouse;
+    int controller_touchpad_mode;
+    int controller_touchpad_sensitivity;
+    int controller_touchpad_press;
+    int controller_touchpad_secondary_click;
+    bool controller_touchpad_tap_to_click;
+    bool controller_touchpad_two_finger_scroll;
+    bool controller_touchpad_invert_two_finger_scroll;
+    bool controller_touchpad_webos_touchscreen;
+    bool swap_abxy;
     uint8_t stick_deadzone;
 } session_config_t;
 

--- a/src/app/stream/session_events.c
+++ b/src/app/stream/session_events.c
@@ -3,10 +3,23 @@
 
 
 bool session_handle_input_event(session_t *session, const SDL_Event *event) {
+    stream_input_t *input = &session->input;
+
+    // Keep controller connection state synchronized even while the streaming
+    // overlay is blocking normal input. Otherwise a disconnect/reconnect can
+    // leave announced_gamepad_mask stale and prevent the controller from being
+    // announced again when gameplay input resumes.
+    if (event->type == SDL_JOYDEVICEADDED || event->type == SDL_JOYDEVICEREMOVED) {
+        if (input->started) {
+            stream_input_sync_gamepads(input);
+            return true;
+        }
+        return false;
+    }
+
     if (!session_accepting_input(session)) {
         return false;
     }
-    stream_input_t *input = &session->input;
     switch (event->type) {
         case SDL_KEYDOWN:
         case SDL_KEYUP: {
@@ -30,10 +43,6 @@ bool session_handle_input_event(session_t *session, const SDL_Event *event) {
         case SDL_CONTROLLERTOUCHPADMOTION:
         case SDL_CONTROLLERTOUCHPADUP: {
             stream_input_handle_ctouchpad(input, &event->ctouchpad);
-            break;
-        }
-        case SDL_CONTROLLERDEVICEADDED: {
-            stream_input_handle_cdevice(input, &event->cdevice);
             break;
         }
         case SDL_MOUSEMOTION: {
@@ -67,4 +76,20 @@ bool session_handle_input_event(session_t *session, const SDL_Event *event) {
             return false;
     }
     return true;
+}
+
+void session_flush_input_events(session_t *session) {
+    if (!session_accepting_input(session)) {
+        return;
+    }
+
+    stream_input_t *input = &session->input;
+#if TARGET_WEBOS
+    if (input->controller_touchpad_compat != NULL) {
+        stream_input_flush_pending_touch(input);
+    }
+#endif
+    if (input->controller_touchpads != NULL && input->controller_touchpad_tap_to_click) {
+        stream_input_flush_controller_touchpad_tap_hold(input);
+    }
 }

--- a/src/app/stream/session_events.h
+++ b/src/app/stream/session_events.h
@@ -6,3 +6,5 @@
 typedef struct session_t session_t;
 
 bool session_handle_input_event(session_t *session, const SDL_Event *event);
+
+void session_flush_input_events(session_t *session);

--- a/src/app/ui/settings/panes/input.pane.c
+++ b/src/app/ui/settings/panes/input.pane.c
@@ -3,6 +3,8 @@
 
 #include "pref_obj.h"
 
+#include "lvgl/util/lv_app_utils.h"
+
 #include "util/i18n.h"
 
 typedef struct input_pane_t {
@@ -11,11 +13,31 @@ typedef struct input_pane_t {
     lv_obj_t *absmouse_toggle;
     lv_obj_t *absmouse_hint;
     lv_obj_t *deadzone_label;
+
+    pref_dropdown_int_entry_t controller_touchpad_mode_entries[3];
+    pref_dropdown_int_entry_t controller_touchpad_press_entries[4];
+
+    lv_obj_t *controller_touchpad_sensitivity_label;
+    lv_obj_t *controller_touchpad_mouse_controls[6];
 } input_pane_t;
 
 static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *view);
 
-static void pane_ctor(lv_fragment_t *self, void *args);
+static void build_input_page(input_pane_t *pane, lv_obj_t *view);
+
+static void on_controller_touchpad_mode_changed(lv_event_t *e);
+
+#if TARGET_WEBOS
+static void show_controller_touchpad_webos25_notice(void);
+
+static void controller_touchpad_webos25_notice_cb(lv_event_t *e);
+#endif
+
+static void on_controller_touchpad_sensitivity_changed(lv_event_t *e);
+
+static void update_controller_touchpad_mouse_options(input_pane_t *pane);
+
+static void update_controller_touchpad_sensitivity_label(input_pane_t *pane);
 
 #if FEATURE_INPUT_EVMOUSE
 static void hwmouse_state_update_cb(lv_event_t *e);
@@ -28,14 +50,9 @@ static void update_deadzone_label(input_pane_t *pane);
 static void on_deadzone_changed(lv_event_t *e);
 
 const lv_fragment_class_t settings_pane_input_cls = {
-        .constructor_cb = pane_ctor,
         .create_obj_cb = create_obj,
         .instance_size = sizeof(input_pane_t),
 };
-
-static void pane_ctor(lv_fragment_t *self, void *args) {
-
-}
 
 static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     input_pane_t *pane = (input_pane_t *) self;
@@ -43,6 +60,28 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_set_layout(view, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(view, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(view, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+
+    build_input_page(pane, view);
+    return view;
+}
+
+static void build_input_page(input_pane_t *pane, lv_obj_t *view) {
+    pane->controller_touchpad_mode_entries[0] = (pref_dropdown_int_entry_t) {
+            locstr("Disabled"), CONTROLLER_TOUCHPAD_MODE_DISABLED, false};
+    pane->controller_touchpad_mode_entries[1] = (pref_dropdown_int_entry_t) {
+            locstr("Mouse"), CONTROLLER_TOUCHPAD_MODE_MOUSE, true};
+    pane->controller_touchpad_mode_entries[2] = (pref_dropdown_int_entry_t) {
+            locstr("Native"), CONTROLLER_TOUCHPAD_MODE_NATIVE, false};
+
+    pane->controller_touchpad_press_entries[0] = (pref_dropdown_int_entry_t) {
+            locstr("Off"), CONTROLLER_TOUCHPAD_PRESS_DISABLED, false};
+    pane->controller_touchpad_press_entries[1] = (pref_dropdown_int_entry_t) {
+            locstr("Left click"), CONTROLLER_TOUCHPAD_PRESS_LEFT, true};
+    pane->controller_touchpad_press_entries[2] = (pref_dropdown_int_entry_t) {
+            locstr("Right click"), CONTROLLER_TOUCHPAD_PRESS_RIGHT, false};
+    pane->controller_touchpad_press_entries[3] = (pref_dropdown_int_entry_t) {
+            locstr("Middle click"), CONTROLLER_TOUCHPAD_PRESS_MIDDLE, false};
+
     pref_checkbox(view, locstr("View-only mode"), &app_configuration->viewonly, false);
     pref_desc_label(view, locstr("Don't send mouse, keyboard or gamepad input to host computer."), false);
 
@@ -56,14 +95,14 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
                                              &app_configuration->hardware_mouse, false);
     lv_obj_add_event_cb(hwmouse_toggle, hwmouse_state_update_cb, LV_EVENT_VALUE_CHANGED, pane);
     pref_desc_label(view, locstr("Use plugged mouse device only when streaming. "
-                                 "This will have better performance, but absolute mouse mode will not be enabled."),
+                                       "This will have better performance, but absolute mouse mode will not be enabled."),
                     false);
 #endif
 
     pane->absmouse_toggle = pref_checkbox(view, locstr("Absolute mouse mode"),
                                           &app_configuration->absmouse, false);
     pane->absmouse_hint = pref_desc_label(view, locstr("Better for remote desktop. "
-                                                       "For some games, mouse will not work properly."), false);
+                                                             "For some games, mouse will not work properly."), false);
 
     pref_header(view, locstr("Gamepad"));
 
@@ -72,22 +111,161 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_set_width(deadzone_slider, LV_PCT(100));
     lv_obj_add_event_cb(deadzone_slider, on_deadzone_changed, LV_EVENT_VALUE_CHANGED, pane);
     pref_desc_label(view, locstr("Note: Some games can enforce a larger deadzone "
-                                 "than what Moonlight is configured to use."), false);
+                                       "than what Moonlight is configured to use."), false);
 
     pref_checkbox(view, locstr("Virtual mouse"), &app_configuration->virtual_mouse, false);
     pref_desc_label(view, locstr("Press LB + RS to move mouse cursor with sticks. "
-                                 "LT/RT for left/right mouse buttons."), false);
+                                       "LT/RT for left/right mouse buttons."), false);
 
     pref_checkbox(view, locstr("Swap ABXY buttons"), &app_configuration->swap_abxy, false);
     pref_desc_label(view, locstr("Swap A/B and X/Y gamepad buttons. Useful when you prefer Nintendo-like layouts."),
                     false);
 
+    pref_header(view, locstr("Controller touchpad"));
+
+    pref_title_label(view, locstr("Mode"));
+    lv_obj_t *mode_dropdown = pref_dropdown_int(view,
+                                                pane->controller_touchpad_mode_entries,
+                                                sizeof(pane->controller_touchpad_mode_entries) /
+                                                        sizeof(*pane->controller_touchpad_mode_entries),
+                                                &app_configuration->controller_touchpad_mode,
+                                                NULL);
+    lv_obj_set_width(mode_dropdown, LV_PCT(100));
+    lv_obj_add_event_cb(mode_dropdown, on_controller_touchpad_mode_changed, LV_EVENT_VALUE_CHANGED, pane);
+    pref_desc_label(view, locstr("Disabled ignores controller touchpad input. Mouse uses it as a relative "
+                                       "trackpad. Native forwards controller touch events and the touchpad button "
+                                       "to the host."), false);
+
+#if TARGET_WEBOS
+    pref_checkbox(view, locstr("This TV has a touchscreen"),
+                  &app_configuration->controller_touchpad_webos_touchscreen, false);
+    pref_desc_label(view,
+                    locstr("Leave this off on most LG TVs to prevent controller touchpads from appearing "
+                           "as touchscreen input on the PC. Enable it for StanbyME or another "
+                           "touch-enabled LG display."),
+                    false);
+#endif
+
+    size_t mouse_control = 0;
+    pane->controller_touchpad_sensitivity_label = pref_title_label(view, NULL);
+    lv_obj_t *sensitivity_slider =
+            pane->controller_touchpad_mouse_controls[mouse_control++] =
+                    pref_slider(view, &app_configuration->controller_touchpad_sensitivity,
+                                CONTROLLER_TOUCHPAD_SENSITIVITY_MIN,
+                                CONTROLLER_TOUCHPAD_SENSITIVITY_MAX, 5);
+    lv_obj_set_width(sensitivity_slider, LV_PCT(100));
+    lv_obj_add_event_cb(sensitivity_slider, on_controller_touchpad_sensitivity_changed,
+                        LV_EVENT_VALUE_CHANGED, pane);
+    pref_desc_label(view, locstr("Adjust relative pointer speed in Mouse mode."), false);
+
+    pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_checkbox(view, locstr("Tap to click"),
+                          &app_configuration->controller_touchpad_tap_to_click, false);
+    pref_desc_label(view, locstr("Tap once with one finger to send a left click. "
+                                 "Touch and hold briefly to hold left click for dragging."), false);
+
+    pref_title_label(view, locstr("Physical press"));
+    lv_obj_t *press_dropdown = pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_dropdown_int(view,
+                              pane->controller_touchpad_press_entries,
+                              sizeof(pane->controller_touchpad_press_entries) /
+                                      sizeof(*pane->controller_touchpad_press_entries),
+                              &app_configuration->controller_touchpad_press,
+                              NULL);
+    lv_obj_set_width(press_dropdown, LV_PCT(100));
+    pref_desc_label(view, locstr("Choose the mouse button sent for a normal physical touchpad press."),
+                    false);
+
+    pref_title_label(view, locstr("Secondary click"));
+    lv_obj_t *secondary_click_dropdown = pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_dropdown_int(view,
+                              pane->controller_touchpad_press_entries,
+                              sizeof(pane->controller_touchpad_press_entries) /
+                                      sizeof(*pane->controller_touchpad_press_entries),
+                              &app_configuration->controller_touchpad_secondary_click,
+                              NULL);
+    lv_obj_set_width(secondary_click_dropdown, LV_PCT(100));
+    pref_desc_label(view, locstr("Used for a physical press in the lower-right corner or a two-finger tap."),
+                    false);
+
+    pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_checkbox(view, locstr("Two-finger scrolling"),
+                          &app_configuration->controller_touchpad_two_finger_scroll, false);
+    pref_desc_label(view, locstr("Scroll vertically or horizontally by moving two fingers together."),
+                    false);
+
+    pane->controller_touchpad_mouse_controls[mouse_control] =
+            pref_checkbox(view, locstr("Invert two-finger scrolling"),
+                          &app_configuration->controller_touchpad_invert_two_finger_scroll, false);
+    pref_desc_label(view, locstr("Use natural scrolling so content follows your fingers, like on macOS."),
+                    false);
+
+    update_controller_touchpad_sensitivity_label(pane);
+    update_controller_touchpad_mouse_options(pane);
+
 #if FEATURE_INPUT_EVMOUSE
     hwmouse_state_update(pane);
 #endif
     update_deadzone_label(pane);
-    return view;
 }
+
+static void on_controller_touchpad_mode_changed(lv_event_t *e) {
+    input_pane_t *pane = lv_event_get_user_data(e);
+    update_controller_touchpad_mouse_options(pane);
+
+#if TARGET_WEBOS
+    if (app_configuration->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_MOUSE ||
+        app_configuration->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE) {
+        show_controller_touchpad_webos25_notice();
+    }
+#endif
+}
+
+#if TARGET_WEBOS
+static void show_controller_touchpad_webos25_notice(void) {
+    static const char *btn_txts[] = {translatable("OK"), ""};
+    lv_obj_t *msgbox = lv_msgbox_create_i18n(
+            NULL,
+            locstr("webOS 25 controller touchpad notice"),
+            locstr("As of webOS 25, touchRemoteLaunchMode defaults to \"edgeSwipe\", which can make "
+                   "Bluetooth controller touchpads (for example, Sony DualSense) behave erratically in gaming apps.\n\n"
+                   "To restore the previous \"multiTouch\" behavior, use LGTVcli.exe from the LGTV Companion project "
+                   "on a Windows PC:\n\n"
+                   "LGTVcli.exe -settings_other \"{\\\"touchRemoteLaunchMode\\\":\\\"multiTouch\\\"}\" Device1\n\n"
+                   "Replace Device1 with your configured LGTV Companion device ID or TV name."),
+            btn_txts, false);
+    lv_obj_set_width(msgbox, LV_PCT(80));
+    lv_obj_add_event_cb(msgbox, controller_touchpad_webos25_notice_cb, LV_EVENT_VALUE_CHANGED, NULL);
+    lv_obj_center(msgbox);
+}
+
+static void controller_touchpad_webos25_notice_cb(lv_event_t *e) {
+    lv_msgbox_close_async(lv_event_get_current_target(e));
+}
+#endif
+
+static void on_controller_touchpad_sensitivity_changed(lv_event_t *e) {
+    input_pane_t *pane = lv_event_get_user_data(e);
+    update_controller_touchpad_sensitivity_label(pane);
+}
+
+static void update_controller_touchpad_mouse_options(input_pane_t *pane) {
+    bool mouse_mode = app_configuration->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_MOUSE;
+    for (size_t i = 0; i < sizeof(pane->controller_touchpad_mouse_controls) /
+                           sizeof(*pane->controller_touchpad_mouse_controls); ++i) {
+        if (mouse_mode) {
+            lv_obj_clear_state(pane->controller_touchpad_mouse_controls[i], LV_STATE_DISABLED);
+        } else {
+            lv_obj_add_state(pane->controller_touchpad_mouse_controls[i], LV_STATE_DISABLED);
+        }
+    }
+}
+
+static void update_controller_touchpad_sensitivity_label(input_pane_t *pane) {
+    lv_label_set_text_fmt(pane->controller_touchpad_sensitivity_label, "%s - %d%%",
+                          locstr("Sensitivity"), app_configuration->controller_touchpad_sensitivity);
+}
+
 
 #if FEATURE_INPUT_EVMOUSE
 static void hwmouse_state_update_cb(lv_event_t *e) {

--- a/tests/app/test_settings.c
+++ b/tests/app/test_settings.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include "unity.h"
 #include "app_settings.h"
@@ -27,18 +28,62 @@ void testReadINI() {
     settings.ini_path = FIXTURES_PATH_PREFIX "settings_read.ini";
     TEST_ASSERT_TRUE(settings_read(&settings));
     settings.ini_path = ini_backup;
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, settings.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(125, settings.controller_touchpad_sensitivity);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_RIGHT, settings.controller_touchpad_press);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_MIDDLE, settings.controller_touchpad_secondary_click);
+    TEST_ASSERT_FALSE(settings.controller_touchpad_tap_to_click);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_two_finger_scroll);
+    TEST_ASSERT_FALSE(settings.controller_touchpad_invert_two_finger_scroll);
 }
 
 void testWriteINI() {
+    settings.controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_NATIVE;
+    settings.controller_touchpad_sensitivity = 175;
+    settings.controller_touchpad_press = CONTROLLER_TOUCHPAD_PRESS_MIDDLE;
+    settings.controller_touchpad_secondary_click = CONTROLLER_TOUCHPAD_PRESS_LEFT;
+    settings.controller_touchpad_tap_to_click = false;
+    settings.controller_touchpad_two_finger_scroll = true;
+    settings.controller_touchpad_invert_two_finger_scroll = false;
+
     char *ini_backup = settings.ini_path;
     settings.ini_path = "settings_write_tmp.ini";
     TEST_ASSERT_TRUE(settings_save(&settings));
     settings.ini_path = ini_backup;
+
+    app_settings_t loaded;
+    settings_initialize(&loaded, settings.conf_dir);
+    char *loaded_ini_backup = loaded.ini_path;
+    loaded.ini_path = "settings_write_tmp.ini";
+    TEST_ASSERT_TRUE(settings_read(&loaded));
+    loaded.ini_path = loaded_ini_backup;
+
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_NATIVE, loaded.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(175, loaded.controller_touchpad_sensitivity);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_MIDDLE, loaded.controller_touchpad_press);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_LEFT, loaded.controller_touchpad_secondary_click);
+    TEST_ASSERT_FALSE(loaded.controller_touchpad_tap_to_click);
+    TEST_ASSERT_TRUE(loaded.controller_touchpad_two_finger_scroll);
+    TEST_ASSERT_FALSE(loaded.controller_touchpad_invert_two_finger_scroll);
+
+    settings_clear(&loaded);
+    remove("settings_write_tmp.ini");
+}
+
+void testControllerTouchpadDefaults() {
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, settings.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT, settings.controller_touchpad_sensitivity);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_LEFT, settings.controller_touchpad_press);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_RIGHT, settings.controller_touchpad_secondary_click);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_tap_to_click);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_two_finger_scroll);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_invert_two_finger_scroll);
 }
 
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testReadINI);
     RUN_TEST(testWriteINI);
+    RUN_TEST(testControllerTouchpadDefaults);
     return UNITY_END();
 }

--- a/tests/fixtures/settings_read.ini
+++ b/tests/fixtures/settings_read.ini
@@ -10,6 +10,15 @@ unknown = true
 hevc = true
 hdr = true
 
+[input]
+controller_touchpad = mouse
+controller_touchpad_sensitivity = 125
+controller_touchpad_press = right
+controller_touchpad_secondary_click = middle
+controller_touchpad_tap_to_click = false
+controller_touchpad_two_finger_scroll = true
+controller_touchpad_invert_two_finger_scroll = false
+
 [video]
 decoder = ffmpeg
 


### PR DESCRIPTION
# Add controller touchpad support and improve webOS touch handling

## Summary

This Pull Request adds proper support for controller touchpads, including the Sony DualShock 4 and DualSense, with configurable **Disabled**, **Mouse**, and **Native** modes.

In **Mouse** mode, the controller touchpad can be used for cursor movement, physical clicking, tap-to-click, tap-and-hold dragging, two-finger scrolling, and two-finger right click. **Native** mode forwards controller touchpad input through Moonlight's native controller-touch protocol.

## webOS touch handling

webOS may generate generic touchscreen compatibility events alongside controller touchpad events. These duplicate events could previously reach the host as real touchscreen input, causing stuck or momentary Windows touch contacts.

This commit also improves the filtering and correlation of those compatibility events while preserving support for actual touchscreen devices. Ambiguous touch DOWN events are briefly deferred when a touchpad-capable controller is present, allowing controller-generated duplicates to be identified before they are forwarded to the host.

Touchpad state handling has also been improved so held mouse buttons are properly released when fingers are lifted, additional fingers are added, the physical touchpad button is pressed, or the controller/input state is reset.

## webOS 25 notice

As of webOS 25, `touchRemoteLaunchMode` defaults to `"edgeSwipe"`, which can cause Bluetooth controller touchpads such as the Sony DualSense to behave erratically in gaming applications.

When selecting **Mouse** or **Native** mode on webOS, Moonlight displays a notice explaining how to restore the previous `"multiTouch"` behavior using `LGTVcli.exe` from the LGTV Companion project:

```bat
LGTVcli.exe -settings_other "{\"touchRemoteLaunchMode\":\"multiTouch\"}" Device1
```

`Device1` should be replaced with the configured LGTV Companion device ID or TV name.

## Testing

Tested with controller touchpad cursor movement, clicking, tap-to-click, tap-and-hold dragging, two-finger scrolling, right click, continuous movement without stuck touchscreen contacts, physical touchscreen input while a controller is connected, and controller disconnect/reset handling.
