### PR TITLE
Improve controller touchpad, hotplug, and multi-controller support

### DIFF
--- a/src/app/app.c
+++ b/src/app/app.c
@@ -274,7 +274,7 @@ void app_process_events(app_t *app) {
     SDL_PumpEvents();
     SDL_FilterEvents(app_event_filter, app);
     if (app->session != NULL) {
-        session_update_controller_touchpad_tap_hold(app->session);
+        session_update_touchpad_tap_hold(app->session);
     }
 }
 

--- a/src/app/app.c
+++ b/src/app/app.c
@@ -273,6 +273,9 @@ static int app_event_filter(void *userdata, SDL_Event *event) {
 void app_process_events(app_t *app) {
     SDL_PumpEvents();
     SDL_FilterEvents(app_event_filter, app);
+    if (app->session != NULL) {
+        session_update_controller_touchpad_tap_hold(app->session);
+    }
 }
 
 void app_quit_confirm() {

--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -22,12 +22,21 @@ static const char *serialize_audio_config(int config);
 
 static int parse_audio_config(const char *value);
 
+static const char *indexed_setting_serialize(const char *const values[], size_t count, int value, int fallback);
+
+static int indexed_setting_parse(const char *value, const char *const values[], size_t count, int fallback);
+
 static int settings_parse(app_settings_t *config, const char *section, const char *name, const char *value);
 
 static void set_string(char **field, const char *value);
 
 static void set_int(int *field, const char *value);
 
+
+#define SETTINGS_COUNT(values) (sizeof(values) / sizeof((values)[0]))
+
+static const char *const controller_touchpad_mode_values[] = {"off", "mouse", "native"};
+static const char *const controller_touchpad_press_values[] = {"off", "left", "right", "middle"};
 
 const audio_config_entry_t audio_configs[] = {
         {AUDIO_CONFIGURATION_STEREO,      "stereo", translatable("Stereo")},
@@ -67,6 +76,13 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->rotate = 0;
     config->absmouse = true;
     config->virtual_mouse = false;
+    config->controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_MOUSE;
+    config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT;
+    config->controller_touchpad_press = CONTROLLER_TOUCHPAD_PRESS_LEFT;
+    config->controller_touchpad_secondary_click = CONTROLLER_TOUCHPAD_PRESS_RIGHT;
+    config->controller_touchpad_tap_to_click = true;
+    config->controller_touchpad_two_finger_scroll = true;
+    config->controller_touchpad_invert_two_finger_scroll = true;
     config->hdr = false;
     config->hevc = true;
     config->av1 = false;
@@ -111,6 +127,24 @@ bool settings_save(app_settings_t *config) {
     ini_write_section(fp, "input");
     ini_write_bool(fp, "absmouse", config->absmouse);
     ini_write_bool(fp, "virtual_mouse", config->virtual_mouse);
+    ini_write_string(fp, "controller_touchpad",
+                     indexed_setting_serialize(controller_touchpad_mode_values,
+                                               SETTINGS_COUNT(controller_touchpad_mode_values),
+                                               config->controller_touchpad_mode, CONTROLLER_TOUCHPAD_MODE_MOUSE));
+    ini_write_int(fp, "controller_touchpad_sensitivity", config->controller_touchpad_sensitivity);
+    ini_write_string(fp, "controller_touchpad_press",
+                     indexed_setting_serialize(controller_touchpad_press_values,
+                                               SETTINGS_COUNT(controller_touchpad_press_values),
+                                               config->controller_touchpad_press, CONTROLLER_TOUCHPAD_PRESS_LEFT));
+    ini_write_string(fp, "controller_touchpad_secondary_click",
+                     indexed_setting_serialize(controller_touchpad_press_values,
+                                               SETTINGS_COUNT(controller_touchpad_press_values),
+                                               config->controller_touchpad_secondary_click, CONTROLLER_TOUCHPAD_PRESS_RIGHT));
+    ini_write_bool(fp, "controller_touchpad_tap_to_click", config->controller_touchpad_tap_to_click);
+    ini_write_bool(fp, "controller_touchpad_two_finger_scroll",
+                   config->controller_touchpad_two_finger_scroll);
+    ini_write_bool(fp, "controller_touchpad_invert_two_finger_scroll",
+                   config->controller_touchpad_invert_two_finger_scroll);
 #if FEATURE_INPUT_EVMOUSE
     ini_write_bool(fp, "hardware_mouse", config->hardware_mouse);
 #endif
@@ -221,6 +255,26 @@ int find_ch_idx_by_value(const char *value) {
     return -1;
 }
 
+static const char *indexed_setting_serialize(const char *const values[], size_t count,
+                                             int value, int fallback) {
+    if ((unsigned int) value >= count) {
+        value = fallback;
+    }
+    return values[value];
+}
+
+static int indexed_setting_parse(const char *value, const char *const values[],
+                                 size_t count, int fallback) {
+    if (value != NULL) {
+        for (size_t i = 0; i < count; ++i) {
+            if (strcmp(value, values[i]) == 0) {
+                return (int) i;
+            }
+        }
+    }
+    return fallback;
+}
+
 static int settings_parse(app_settings_t *config, const char *section, const char *name, const char *value) {
     if (INI_FULL_MATCH("streaming", "width")) {
         set_int(&config->stream.width, value);
@@ -254,6 +308,34 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         config->absmouse = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("virtual_mouse")) {
         config->virtual_mouse = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad")) {
+        config->controller_touchpad_mode = indexed_setting_parse(
+                value, controller_touchpad_mode_values,
+                SETTINGS_COUNT(controller_touchpad_mode_values),
+                CONTROLLER_TOUCHPAD_MODE_MOUSE);
+    } else if (INI_NAME_MATCH("controller_touchpad_sensitivity")) {
+        set_int(&config->controller_touchpad_sensitivity, value);
+        if (config->controller_touchpad_sensitivity < CONTROLLER_TOUCHPAD_SENSITIVITY_MIN) {
+            config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_MIN;
+        } else if (config->controller_touchpad_sensitivity > CONTROLLER_TOUCHPAD_SENSITIVITY_MAX) {
+            config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_MAX;
+        }
+    } else if (INI_NAME_MATCH("controller_touchpad_press")) {
+        config->controller_touchpad_press = indexed_setting_parse(
+                value, controller_touchpad_press_values,
+                SETTINGS_COUNT(controller_touchpad_press_values),
+                CONTROLLER_TOUCHPAD_PRESS_LEFT);
+    } else if (INI_NAME_MATCH("controller_touchpad_secondary_click")) {
+        config->controller_touchpad_secondary_click = indexed_setting_parse(
+                value, controller_touchpad_press_values,
+                SETTINGS_COUNT(controller_touchpad_press_values),
+                CONTROLLER_TOUCHPAD_PRESS_RIGHT);
+    } else if (INI_NAME_MATCH("controller_touchpad_tap_to_click")) {
+        config->controller_touchpad_tap_to_click = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad_two_finger_scroll")) {
+        config->controller_touchpad_two_finger_scroll = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad_invert_two_finger_scroll")) {
+        config->controller_touchpad_invert_two_finger_scroll = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("hardware_mouse")) {
 #if FEATURE_INPUT_EVMOUSE
         config->hardware_mouse = INI_IS_TRUE(value);

--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -35,8 +35,7 @@ static void set_int(int *field, const char *value);
 
 #define SETTINGS_COUNT(values) (sizeof(values) / sizeof((values)[0]))
 
-static const char *const controller_touchpad_mode_values[] = {"off", "mouse", "native"};
-static const char *const controller_touchpad_press_values[] = {"off", "left", "right", "middle"};
+static const char *const controller_touchpad_mode_values[] = {"mouse", "native"};
 
 const audio_config_entry_t audio_configs[] = {
         {AUDIO_CONFIGURATION_STEREO,      "stereo", translatable("Stereo")},
@@ -76,13 +75,10 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->rotate = 0;
     config->absmouse = true;
     config->virtual_mouse = false;
-    config->controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_MOUSE;
+    config->controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_NATIVE;
     config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT;
-    config->controller_touchpad_press = CONTROLLER_TOUCHPAD_PRESS_LEFT;
-    config->controller_touchpad_secondary_click = CONTROLLER_TOUCHPAD_PRESS_RIGHT;
-    config->controller_touchpad_tap_to_click = true;
-    config->controller_touchpad_two_finger_scroll = true;
-    config->controller_touchpad_invert_two_finger_scroll = true;
+    config->controller_touchpad_multitouch = true;
+    config->controller_touchpad_natural_scroll = true;
     config->hdr = false;
     config->hevc = true;
     config->av1 = false;
@@ -130,21 +126,10 @@ bool settings_save(app_settings_t *config) {
     ini_write_string(fp, "controller_touchpad",
                      indexed_setting_serialize(controller_touchpad_mode_values,
                                                SETTINGS_COUNT(controller_touchpad_mode_values),
-                                               config->controller_touchpad_mode, CONTROLLER_TOUCHPAD_MODE_MOUSE));
+                                               config->controller_touchpad_mode, CONTROLLER_TOUCHPAD_MODE_NATIVE));
     ini_write_int(fp, "controller_touchpad_sensitivity", config->controller_touchpad_sensitivity);
-    ini_write_string(fp, "controller_touchpad_press",
-                     indexed_setting_serialize(controller_touchpad_press_values,
-                                               SETTINGS_COUNT(controller_touchpad_press_values),
-                                               config->controller_touchpad_press, CONTROLLER_TOUCHPAD_PRESS_LEFT));
-    ini_write_string(fp, "controller_touchpad_secondary_click",
-                     indexed_setting_serialize(controller_touchpad_press_values,
-                                               SETTINGS_COUNT(controller_touchpad_press_values),
-                                               config->controller_touchpad_secondary_click, CONTROLLER_TOUCHPAD_PRESS_RIGHT));
-    ini_write_bool(fp, "controller_touchpad_tap_to_click", config->controller_touchpad_tap_to_click);
-    ini_write_bool(fp, "controller_touchpad_two_finger_scroll",
-                   config->controller_touchpad_two_finger_scroll);
-    ini_write_bool(fp, "controller_touchpad_invert_two_finger_scroll",
-                   config->controller_touchpad_invert_two_finger_scroll);
+    ini_write_bool(fp, "controller_touchpad_multitouch", config->controller_touchpad_multitouch);
+    ini_write_bool(fp, "controller_touchpad_natural_scroll", config->controller_touchpad_natural_scroll);
 #if FEATURE_INPUT_EVMOUSE
     ini_write_bool(fp, "hardware_mouse", config->hardware_mouse);
 #endif
@@ -309,10 +294,16 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
     } else if (INI_NAME_MATCH("virtual_mouse")) {
         config->virtual_mouse = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("controller_touchpad")) {
-        config->controller_touchpad_mode = indexed_setting_parse(
-                value, controller_touchpad_mode_values,
-                SETTINGS_COUNT(controller_touchpad_mode_values),
-                CONTROLLER_TOUCHPAD_MODE_MOUSE);
+        /* "off" was a third mode in early revisions of this feature; it never shipped,
+         * but map it rather than silently falling back to a different default. */
+        if (value != NULL && strcmp(value, "off") == 0) {
+            config->controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_NATIVE;
+        } else {
+            config->controller_touchpad_mode = indexed_setting_parse(
+                    value, controller_touchpad_mode_values,
+                    SETTINGS_COUNT(controller_touchpad_mode_values),
+                    CONTROLLER_TOUCHPAD_MODE_NATIVE);
+        }
     } else if (INI_NAME_MATCH("controller_touchpad_sensitivity")) {
         set_int(&config->controller_touchpad_sensitivity, value);
         if (config->controller_touchpad_sensitivity < CONTROLLER_TOUCHPAD_SENSITIVITY_MIN) {
@@ -320,22 +311,10 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         } else if (config->controller_touchpad_sensitivity > CONTROLLER_TOUCHPAD_SENSITIVITY_MAX) {
             config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_MAX;
         }
-    } else if (INI_NAME_MATCH("controller_touchpad_press")) {
-        config->controller_touchpad_press = indexed_setting_parse(
-                value, controller_touchpad_press_values,
-                SETTINGS_COUNT(controller_touchpad_press_values),
-                CONTROLLER_TOUCHPAD_PRESS_LEFT);
-    } else if (INI_NAME_MATCH("controller_touchpad_secondary_click")) {
-        config->controller_touchpad_secondary_click = indexed_setting_parse(
-                value, controller_touchpad_press_values,
-                SETTINGS_COUNT(controller_touchpad_press_values),
-                CONTROLLER_TOUCHPAD_PRESS_RIGHT);
-    } else if (INI_NAME_MATCH("controller_touchpad_tap_to_click")) {
-        config->controller_touchpad_tap_to_click = INI_IS_TRUE(value);
-    } else if (INI_NAME_MATCH("controller_touchpad_two_finger_scroll")) {
-        config->controller_touchpad_two_finger_scroll = INI_IS_TRUE(value);
-    } else if (INI_NAME_MATCH("controller_touchpad_invert_two_finger_scroll")) {
-        config->controller_touchpad_invert_two_finger_scroll = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad_multitouch")) {
+        config->controller_touchpad_multitouch = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("controller_touchpad_natural_scroll")) {
+        config->controller_touchpad_natural_scroll = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("hardware_mouse")) {
 #if FEATURE_INPUT_EVMOUSE
         config->hardware_mouse = INI_IS_TRUE(value);

--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -35,7 +35,7 @@ static void set_int(int *field, const char *value);
 
 #define SETTINGS_COUNT(values) (sizeof(values) / sizeof((values)[0]))
 
-static const char *const controller_touchpad_mode_values[] = {"mouse", "native"};
+static const char *const touchpad_mode_values[] = {"mouse", "native"};
 
 const audio_config_entry_t audio_configs[] = {
         {AUDIO_CONFIGURATION_STEREO,      "stereo", translatable("Stereo")},
@@ -75,10 +75,10 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->rotate = 0;
     config->absmouse = true;
     config->virtual_mouse = false;
-    config->controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_NATIVE;
-    config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT;
-    config->controller_touchpad_multitouch = true;
-    config->controller_touchpad_natural_scroll = true;
+    config->touchpad_mode = TOUCHPAD_MODE_NATIVE;
+    config->touchpad_speed = TOUCHPAD_SPEED_DEFAULT;
+    config->touchpad_multitouch = true;
+    config->touchpad_natural_scroll = true;
     config->hdr = false;
     config->hevc = true;
     config->av1 = false;
@@ -123,13 +123,13 @@ bool settings_save(app_settings_t *config) {
     ini_write_section(fp, "input");
     ini_write_bool(fp, "absmouse", config->absmouse);
     ini_write_bool(fp, "virtual_mouse", config->virtual_mouse);
-    ini_write_string(fp, "controller_touchpad",
-                     indexed_setting_serialize(controller_touchpad_mode_values,
-                                               SETTINGS_COUNT(controller_touchpad_mode_values),
-                                               config->controller_touchpad_mode, CONTROLLER_TOUCHPAD_MODE_NATIVE));
-    ini_write_int(fp, "controller_touchpad_sensitivity", config->controller_touchpad_sensitivity);
-    ini_write_bool(fp, "controller_touchpad_multitouch", config->controller_touchpad_multitouch);
-    ini_write_bool(fp, "controller_touchpad_natural_scroll", config->controller_touchpad_natural_scroll);
+    ini_write_string(fp, "touchpad_mode",
+                     indexed_setting_serialize(touchpad_mode_values,
+                                               SETTINGS_COUNT(touchpad_mode_values),
+                                               config->touchpad_mode, TOUCHPAD_MODE_NATIVE));
+    ini_write_int(fp, "touchpad_speed", config->touchpad_speed);
+    ini_write_bool(fp, "touchpad_multitouch", config->touchpad_multitouch);
+    ini_write_bool(fp, "touchpad_natural_scroll", config->touchpad_natural_scroll);
 #if FEATURE_INPUT_EVMOUSE
     ini_write_bool(fp, "hardware_mouse", config->hardware_mouse);
 #endif
@@ -293,28 +293,21 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         config->absmouse = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("virtual_mouse")) {
         config->virtual_mouse = INI_IS_TRUE(value);
-    } else if (INI_NAME_MATCH("controller_touchpad")) {
-        /* "off" was a third mode in early revisions of this feature; it never shipped,
-         * but map it rather than silently falling back to a different default. */
-        if (value != NULL && strcmp(value, "off") == 0) {
-            config->controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_NATIVE;
-        } else {
-            config->controller_touchpad_mode = indexed_setting_parse(
-                    value, controller_touchpad_mode_values,
-                    SETTINGS_COUNT(controller_touchpad_mode_values),
-                    CONTROLLER_TOUCHPAD_MODE_NATIVE);
+    } else if (INI_NAME_MATCH("touchpad_mode")) {
+        config->touchpad_mode = indexed_setting_parse(
+                value, touchpad_mode_values, SETTINGS_COUNT(touchpad_mode_values),
+                TOUCHPAD_MODE_NATIVE);
+    } else if (INI_NAME_MATCH("touchpad_speed")) {
+        set_int(&config->touchpad_speed, value);
+        if (config->touchpad_speed < TOUCHPAD_SPEED_MIN) {
+            config->touchpad_speed = TOUCHPAD_SPEED_MIN;
+        } else if (config->touchpad_speed > TOUCHPAD_SPEED_MAX) {
+            config->touchpad_speed = TOUCHPAD_SPEED_MAX;
         }
-    } else if (INI_NAME_MATCH("controller_touchpad_sensitivity")) {
-        set_int(&config->controller_touchpad_sensitivity, value);
-        if (config->controller_touchpad_sensitivity < CONTROLLER_TOUCHPAD_SENSITIVITY_MIN) {
-            config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_MIN;
-        } else if (config->controller_touchpad_sensitivity > CONTROLLER_TOUCHPAD_SENSITIVITY_MAX) {
-            config->controller_touchpad_sensitivity = CONTROLLER_TOUCHPAD_SENSITIVITY_MAX;
-        }
-    } else if (INI_NAME_MATCH("controller_touchpad_multitouch")) {
-        config->controller_touchpad_multitouch = INI_IS_TRUE(value);
-    } else if (INI_NAME_MATCH("controller_touchpad_natural_scroll")) {
-        config->controller_touchpad_natural_scroll = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("touchpad_multitouch")) {
+        config->touchpad_multitouch = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("touchpad_natural_scroll")) {
+        config->touchpad_natural_scroll = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("hardware_mouse")) {
 #if FEATURE_INPUT_EVMOUSE
         config->hardware_mouse = INI_IS_TRUE(value);

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -28,13 +28,13 @@ typedef struct window_state_t {
 } window_state_t;
 
 enum {
-    CONTROLLER_TOUCHPAD_MODE_MOUSE = 0,
-    CONTROLLER_TOUCHPAD_MODE_NATIVE = 1,
+    TOUCHPAD_MODE_MOUSE = 0,
+    TOUCHPAD_MODE_NATIVE = 1,
 };
 
-#define CONTROLLER_TOUCHPAD_SENSITIVITY_MIN 25
-#define CONTROLLER_TOUCHPAD_SENSITIVITY_MAX 200
-#define CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT 100
+#define TOUCHPAD_SPEED_MIN 25
+#define TOUCHPAD_SPEED_MAX 200
+#define TOUCHPAD_SPEED_DEFAULT 100
 
 typedef struct app_settings_t {
     STREAM_CONFIGURATION stream;
@@ -54,10 +54,10 @@ typedef struct app_settings_t {
     bool absmouse;
     bool hardware_mouse;
     bool virtual_mouse;
-    int controller_touchpad_mode;
-    int controller_touchpad_sensitivity;
-    bool controller_touchpad_multitouch;
-    bool controller_touchpad_natural_scroll;
+    int touchpad_mode;
+    int touchpad_speed;
+    bool touchpad_multitouch;
+    bool touchpad_natural_scroll;
     bool swap_abxy;
     bool syskey_capture;
     bool hdr;

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -28,16 +28,8 @@ typedef struct window_state_t {
 } window_state_t;
 
 enum {
-    CONTROLLER_TOUCHPAD_MODE_DISABLED = 0,
-    CONTROLLER_TOUCHPAD_MODE_MOUSE = 1,
-    CONTROLLER_TOUCHPAD_MODE_NATIVE = 2,
-};
-
-enum {
-    CONTROLLER_TOUCHPAD_PRESS_DISABLED = 0,
-    CONTROLLER_TOUCHPAD_PRESS_LEFT = 1,
-    CONTROLLER_TOUCHPAD_PRESS_RIGHT = 2,
-    CONTROLLER_TOUCHPAD_PRESS_MIDDLE = 3,
+    CONTROLLER_TOUCHPAD_MODE_MOUSE = 0,
+    CONTROLLER_TOUCHPAD_MODE_NATIVE = 1,
 };
 
 #define CONTROLLER_TOUCHPAD_SENSITIVITY_MIN 25
@@ -64,11 +56,8 @@ typedef struct app_settings_t {
     bool virtual_mouse;
     int controller_touchpad_mode;
     int controller_touchpad_sensitivity;
-    int controller_touchpad_press;
-    int controller_touchpad_secondary_click;
-    bool controller_touchpad_tap_to_click;
-    bool controller_touchpad_two_finger_scroll;
-    bool controller_touchpad_invert_two_finger_scroll;
+    bool controller_touchpad_multitouch;
+    bool controller_touchpad_natural_scroll;
     bool swap_abxy;
     bool syskey_capture;
     bool hdr;

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -27,6 +27,23 @@ typedef struct window_state_t {
     int x, y, w, h;
 } window_state_t;
 
+enum {
+    CONTROLLER_TOUCHPAD_MODE_DISABLED = 0,
+    CONTROLLER_TOUCHPAD_MODE_MOUSE = 1,
+    CONTROLLER_TOUCHPAD_MODE_NATIVE = 2,
+};
+
+enum {
+    CONTROLLER_TOUCHPAD_PRESS_DISABLED = 0,
+    CONTROLLER_TOUCHPAD_PRESS_LEFT = 1,
+    CONTROLLER_TOUCHPAD_PRESS_RIGHT = 2,
+    CONTROLLER_TOUCHPAD_PRESS_MIDDLE = 3,
+};
+
+#define CONTROLLER_TOUCHPAD_SENSITIVITY_MIN 25
+#define CONTROLLER_TOUCHPAD_SENSITIVITY_MAX 200
+#define CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT 100
+
 typedef struct app_settings_t {
     STREAM_CONFIGURATION stream;
     int debug_level;
@@ -45,6 +62,13 @@ typedef struct app_settings_t {
     bool absmouse;
     bool hardware_mouse;
     bool virtual_mouse;
+    int controller_touchpad_mode;
+    int controller_touchpad_sensitivity;
+    int controller_touchpad_press;
+    int controller_touchpad_secondary_click;
+    bool controller_touchpad_tap_to_click;
+    bool controller_touchpad_two_finger_scroll;
+    bool controller_touchpad_invert_two_finger_scroll;
     bool swap_abxy;
     bool syskey_capture;
     bool hdr;

--- a/src/app/stream/input/session_gamepad.c
+++ b/src/app/stream/input/session_gamepad.c
@@ -167,51 +167,32 @@ void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButt
             button = RB_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_TOUCHPAD:
-            switch (input->controller_touchpad_mode) {
-                case CONTROLLER_TOUCHPAD_MODE_DISABLED:
-                    return;
-                case CONTROLLER_TOUCHPAD_MODE_MOUSE: {
-                    if (input->view_only) {
-                        return;
-                    }
-
-                    session_input_controller_touchpad_t *state =
-                            controller_touchpad_state(input, gamepad);
-                    int mouse_button = 0;
-                    if (event->type == SDL_CONTROLLERBUTTONDOWN) {
-                        if (state != NULL) {
-                            // A physical click always wins over a tap gesture or drag.
-                            controller_touchpad_end_tap(state);
-                        }
-
-                        mouse_button = input->controller_touchpad_press_button;
-                        if (state != NULL && controller_touchpad_lower_right_press(state)) {
-                            mouse_button = input->controller_touchpad_secondary_button;
-                        }
-                        if (state != NULL) {
-                            // 0 means not pressed; -1 means physically pressed with no mapping.
-                            state->physical_mouse_button = (int8_t) (mouse_button != 0 ? mouse_button : -1);
-                        }
-                    } else if (state != NULL) {
-                        mouse_button = state->physical_mouse_button > 0 ? state->physical_mouse_button : 0;
-                        state->physical_mouse_button = 0;
-                    } else {
-                        mouse_button = input->controller_touchpad_press_button;
-                    }
-
-                    if (mouse_button != 0) {
-                        LiSendMouseButtonEvent(event->type == SDL_CONTROLLERBUTTONDOWN ?
-                                               BUTTON_ACTION_PRESS : BUTTON_ACTION_RELEASE,
-                                               mouse_button);
-                    }
+            if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_MOUSE) {
+                if (input->view_only) {
                     return;
                 }
-                case CONTROLLER_TOUCHPAD_MODE_NATIVE:
-                    button = TOUCHPAD_FLAG;
-                    break;
-                default:
-                    return;
+
+                session_input_controller_touchpad_t *state = controller_touchpad_state(input, gamepad);
+                int mouse_button = BUTTON_LEFT;
+                if (event->type == SDL_CONTROLLERBUTTONDOWN) {
+                    if (state != NULL) {
+                        // A physical click always wins over a tap gesture or drag.
+                        controller_touchpad_end_tap(state);
+                        if (controller_touchpad_lower_right_press(state)) {
+                            mouse_button = BUTTON_RIGHT;
+                        }
+                        state->physical_mouse_button = (int8_t) mouse_button;
+                    }
+                } else if (state != NULL) {
+                    mouse_button = state->physical_mouse_button > 0 ? state->physical_mouse_button : BUTTON_LEFT;
+                    state->physical_mouse_button = 0;
+                }
+
+                LiSendMouseButtonEvent(event->type == SDL_CONTROLLERBUTTONDOWN ?
+                                       BUTTON_ACTION_PRESS : BUTTON_ACTION_RELEASE, mouse_button);
+                return;
             }
+            button = TOUCHPAD_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_MISC1:
             button = MISC_FLAG;
@@ -365,12 +346,13 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         return;
     }
 
-    if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_DISABLED) {
+    app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
+    if (gamepad == NULL) {
         return;
     }
 
-    app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
-    if (gamepad == NULL) {
+    // Ignoring every contact past the first disables two-finger gestures wholesale.
+    if (event->finger != 0 && !input->controller_touchpad_multitouch) {
         return;
     }
 
@@ -443,9 +425,7 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         if (two_fingers) {
             controller_touchpad_end_tap(state);
 
-            // Don't delay scrolling/pointer motion for a two-finger tap when
-            // the configured secondary action cannot produce a click.
-            if (input->controller_touchpad_secondary_button != 0) {
+            {
                 uint32_t t0 = state->fingers[0].down_timestamp;
                 uint32_t t1 = state->fingers[1].down_timestamp;
                 uint32_t chord_delta = t0 >= t1 ? t0 - t1 : t1 - t0;
@@ -458,8 +438,7 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
                     state->tap_state = CONTROLLER_TOUCHPAD_TAP_TWO_PENDING;
                 }
             }
-        } else if (state->active_fingers != 0 && input->controller_touchpad_tap_to_click &&
-                   finger != NULL && state->physical_mouse_button == 0) {
+        } else if (state->active_fingers != 0 && finger != NULL && state->physical_mouse_button == 0) {
             state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING;
         }
     } else if (event->type == SDL_CONTROLLERTOUCHPADUP) {
@@ -477,7 +456,7 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
                                  ? state->fingers[0].down_timestamp
                                  : state->fingers[1].down_timestamp;
             if (event->timestamp - tap_start <= CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS) {
-                controller_touchpad_send_mouse_click(input->controller_touchpad_secondary_button);
+                controller_touchpad_send_mouse_click(BUTTON_RIGHT);
             }
             controller_touchpad_end_tap(state);
         }
@@ -490,7 +469,7 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         return;
     }
 
-    if (input->controller_touchpad_two_finger_scroll && two_fingers) {
+    if (two_fingers) {
         if (state->motion_state != CONTROLLER_TOUCHPAD_MOTION_SCROLL ||
             event->type != SDL_CONTROLLERTOUCHPADMOTION) {
             state->motion_state = CONTROLLER_TOUCHPAD_MOTION_SCROLL;

--- a/src/app/stream/input/session_gamepad.c
+++ b/src/app/stream/input/session_gamepad.c
@@ -72,6 +72,10 @@ static void controller_touchpad_reset_state(session_input_controller_touchpad_t 
 
 static bool controller_has_touchpad(const app_gamepad_state_t *gamepad);
 
+static bool controller_touchpad_multitouch(const stream_input_t *input, const app_gamepad_state_t *gamepad);
+
+static float controller_touchpad_aspect(const app_gamepad_state_t *gamepad);
+
 static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state);
 
 static bool controller_touchpad_lower_right_press(const session_input_controller_touchpad_t *state);
@@ -351,8 +355,9 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         return;
     }
 
-    // Ignoring every contact past the first disables two-finger gestures wholesale.
-    if (event->finger != 0 && !input->controller_touchpad_multitouch) {
+    // Ignoring every contact past the first disables two-finger gestures wholesale,
+    // whether the user turned them off or the pad only tracks one finger.
+    if (event->finger != 0 && !controller_touchpad_multitouch(input, gamepad)) {
         return;
     }
 
@@ -525,8 +530,9 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         return;
     }
 
-    state->motion_remainder_x += finger_dx * input->controller_touchpad_mouse_scale_x;
-    state->motion_remainder_y += finger_dy * input->controller_touchpad_mouse_scale_y;
+    float gain = input->controller_touchpad_mouse_gain;
+    state->motion_remainder_x += finger_dx * gain;
+    state->motion_remainder_y += finger_dy * gain * controller_touchpad_aspect(gamepad);
 
     short dx = controller_touchpad_take_delta(&state->motion_remainder_x);
     short dy = controller_touchpad_take_delta(&state->motion_remainder_y);
@@ -604,10 +610,9 @@ void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_s
             break;
         }
     }
-    bool advertise_touchpad =
-            input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE &&
-            controller_has_touchpad(gamepad);
-    if (advertise_touchpad) {
+    // Reported from the hardware rather than the active mode: the pad exists either
+    // way, we simply keep its events to ourselves while it is acting as a mouse.
+    if (controller_has_touchpad(gamepad)) {
         capabilities |= LI_CCAP_TOUCHPAD;
         commons_log_info("Input", "  controller capability: touchpad");
     }
@@ -640,12 +645,8 @@ void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_s
         commons_log_info("Input", "  controller capability: RGB LED");
     }
 #endif
-    uint32_t supported_buttons = 0xFFFFFFFFu;
-    if (!advertise_touchpad) {
-        supported_buttons &= ~(uint32_t) TOUCHPAD_FLAG;
-    }
     LiSendControllerArrivalEvent(gamepad->gs_id, input->input->activeGamepadMask, type,
-                                 supported_buttons, capabilities);
+                                 0xFFFFFFFF, capabilities);
 }
 
 static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state) {
@@ -726,6 +727,43 @@ static bool controller_has_touchpad(const app_gamepad_state_t *gamepad) {
 #else
     return false;
 #endif
+}
+
+static bool controller_touchpad_multitouch(const stream_input_t *input, const app_gamepad_state_t *gamepad) {
+    if (!input->controller_touchpad_multitouch || gamepad->controller == NULL) {
+        return false;
+    }
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    return SDL_GameControllerGetNumTouchpadFingers(gamepad->controller, 0) >= 2;
+#else
+    return false;
+#endif
+}
+
+/* Vertical travel per unit of normalised movement, relative to horizontal.
+ *
+ * SDL normalises touchpad coordinates to 0..1 by dividing out each pad's own
+ * extents, which discards the aspect ratio, so scaling both axes equally makes
+ * vertical movement run fast on any pad that isn't 16:9. The ratios below are
+ * the divisors SDL itself uses -- see TOUCHPAD_SCALEX/TOUCHPAD_SCALEY in
+ * SDL_hidapi_ps4.c, SDL_hidapi_ps5.c and SDL_hidapi_shield.c, which are the only
+ * drivers that report a touchpad at all. */
+static float controller_touchpad_aspect(const app_gamepad_state_t *gamepad) {
+    if (gamepad->controller != NULL) {
+        switch (SDL_GameControllerGetType(gamepad->controller)) {
+            case SDL_CONTROLLER_TYPE_PS4:
+                return 920.0f / 1920.0f;
+            case SDL_CONTROLLER_TYPE_PS5:
+                return 1070.0f / 1920.0f;
+#if SDL_VERSION_ATLEAST(2, 24, 0)
+            case SDL_CONTROLLER_TYPE_NVIDIA_SHIELD:
+                return 21.0f / 80.0f;
+#endif
+            default:
+                break;
+        }
+    }
+    return 9.0f / 16.0f;
 }
 
 static void release_buttons(stream_input_t *input, app_gamepad_state_t *gamepad) {

--- a/src/app/stream/input/session_gamepad.c
+++ b/src/app/stream/input/session_gamepad.c
@@ -2,6 +2,7 @@
 
 #include <Limelight.h>
 
+#include "app_settings.h"
 #include "stream/input/session_input.h"
 
 #include "util/bus.h"
@@ -13,6 +14,42 @@
 
 #define QUIT_BUTTONS (PLAY_FLAG | BACK_FLAG | LB_FLAG | RB_FLAG)
 #define GAMEPAD_COMBO_VMOUSE (LB_FLAG | RS_CLK_FLAG)
+
+#define CONTROLLER_TOUCHPAD_SECONDARY_CORNER 0.75f
+#define CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS 300u
+#define CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ (0.015f * 0.015f)
+#define CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_CHORD_MS 160u
+#define CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ (0.035f * 0.035f)
+#define CONTROLLER_TOUCHPAD_TRACKED_FINGERS 2
+
+enum {
+    CONTROLLER_TOUCHPAD_TAP_NONE = 0,
+    CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING,
+    CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD,
+    CONTROLLER_TOUCHPAD_TAP_TWO_PENDING,
+};
+
+enum {
+    CONTROLLER_TOUCHPAD_MOTION_NONE = 0,
+    CONTROLLER_TOUCHPAD_MOTION_SCROLL,
+    CONTROLLER_TOUCHPAD_MOTION_POINTER_0,
+    CONTROLLER_TOUCHPAD_MOTION_POINTER_1,
+};
+
+typedef struct controller_touchpad_finger_t {
+    float x, y;
+    float down_x, down_y;
+    uint32_t down_timestamp;
+} controller_touchpad_finger_t;
+
+struct session_input_controller_touchpad_t {
+    controller_touchpad_finger_t fingers[CONTROLLER_TOUCHPAD_TRACKED_FINGERS];
+    uint8_t active_fingers;
+    float motion_remainder_x, motion_remainder_y;
+    int8_t physical_mouse_button;
+    uint8_t motion_state;
+    uint8_t tap_state;
+};
 
 static bool quit_combo_pressed = false;
 static bool vmouse_combo_pressed = false;
@@ -27,6 +64,54 @@ static bool sensor_state_needs_update(const app_gamepad_sensor_state_t *state, u
 static bool vmouse_intercepted(stream_input_t *input, const app_gamepad_state_t *gamepad);
 
 static bool filter_deadzone_2axis(stream_input_t *input, short *x, short *y);
+
+static session_input_controller_touchpad_t *controller_touchpad_state(
+        stream_input_t *input, const app_gamepad_state_t *gamepad);
+
+static void controller_touchpad_reset_state(session_input_controller_touchpad_t *state);
+
+static bool controller_has_touchpad(const app_gamepad_state_t *gamepad);
+
+static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state);
+
+static bool controller_touchpad_lower_right_press(const session_input_controller_touchpad_t *state);
+
+static bool controller_touchpad_finger_exceeded_tap_slop(
+        const controller_touchpad_finger_t *finger, float threshold_squared);
+
+static void controller_touchpad_end_tap(session_input_controller_touchpad_t *state);
+
+static void controller_touchpad_send_mouse_click(int mouse_button);
+
+static short controller_touchpad_take_delta(float *remainder);
+
+void stream_input_controller_touchpad_mouse_init(stream_input_t *input) {
+    if (input->controller_touchpads != NULL ||
+        input->controller_touchpad_mode != CONTROLLER_TOUCHPAD_MODE_MOUSE) {
+        return;
+    }
+
+    short count = app_input_get_max_gamepads(input->input);
+    if (count <= 0) {
+        return;
+    }
+
+    input->controller_touchpads = SDL_calloc((size_t) count, sizeof(*input->controller_touchpads));
+    if (input->controller_touchpads != NULL) {
+        input->controller_touchpad_count = count;
+    }
+}
+
+void stream_input_controller_touchpad_mouse_deinit(stream_input_t *input) {
+    if (input->controller_touchpads != NULL) {
+        for (short i = 0; i < input->controller_touchpad_count; ++i) {
+            controller_touchpad_reset_state(&input->controller_touchpads[i]);
+        }
+        SDL_free(input->controller_touchpads);
+        input->controller_touchpads = NULL;
+    }
+    input->controller_touchpad_count = 0;
+}
 
 void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButtonEvent *event) {
     app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
@@ -82,7 +167,51 @@ void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButt
             button = RB_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_TOUCHPAD:
-            button = TOUCHPAD_FLAG;
+            switch (input->controller_touchpad_mode) {
+                case CONTROLLER_TOUCHPAD_MODE_DISABLED:
+                    return;
+                case CONTROLLER_TOUCHPAD_MODE_MOUSE: {
+                    if (input->view_only) {
+                        return;
+                    }
+
+                    session_input_controller_touchpad_t *state =
+                            controller_touchpad_state(input, gamepad);
+                    int mouse_button = 0;
+                    if (event->type == SDL_CONTROLLERBUTTONDOWN) {
+                        if (state != NULL) {
+                            // A physical click always wins over a tap gesture or drag.
+                            controller_touchpad_end_tap(state);
+                        }
+
+                        mouse_button = input->controller_touchpad_press_button;
+                        if (state != NULL && controller_touchpad_lower_right_press(state)) {
+                            mouse_button = input->controller_touchpad_secondary_button;
+                        }
+                        if (state != NULL) {
+                            // 0 means not pressed; -1 means physically pressed with no mapping.
+                            state->physical_mouse_button = (int8_t) (mouse_button != 0 ? mouse_button : -1);
+                        }
+                    } else if (state != NULL) {
+                        mouse_button = state->physical_mouse_button > 0 ? state->physical_mouse_button : 0;
+                        state->physical_mouse_button = 0;
+                    } else {
+                        mouse_button = input->controller_touchpad_press_button;
+                    }
+
+                    if (mouse_button != 0) {
+                        LiSendMouseButtonEvent(event->type == SDL_CONTROLLERBUTTONDOWN ?
+                                               BUTTON_ACTION_PRESS : BUTTON_ACTION_RELEASE,
+                                               mouse_button);
+                    }
+                    return;
+                }
+                case CONTROLLER_TOUCHPAD_MODE_NATIVE:
+                    button = TOUCHPAD_FLAG;
+                    break;
+                default:
+                    return;
+            }
             break;
         case SDL_CONTROLLER_BUTTON_MISC1:
             button = MISC_FLAG;
@@ -232,35 +361,228 @@ void stream_input_handle_csensor(stream_input_t *input, const SDL_ControllerSens
 }
 
 void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTouchpadEvent *event) {
+    if (event->touchpad != 0 || input->view_only) {
+        return;
+    }
+
+    if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_DISABLED) {
+        return;
+    }
+
     app_gamepad_state_t *gamepad = app_input_gamepad_state_by_instance_id(input->input, event->which);
     if (gamepad == NULL) {
         return;
     }
-    if (input->view_only) {
+
+    if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE) {
+        uint8_t native_event_type =
+                event->type == SDL_CONTROLLERTOUCHPADDOWN ? LI_TOUCH_EVENT_DOWN :
+                event->type == SDL_CONTROLLERTOUCHPADUP ? LI_TOUCH_EVENT_UP :
+                                                          LI_TOUCH_EVENT_MOVE;
+        LiSendControllerTouchEvent(gamepad->gs_id, native_event_type, event->finger,
+                                   event->x, event->y, event->pressure);
         return;
     }
-    if (event->touchpad != 0) {
+
+    session_input_controller_touchpad_t *state = controller_touchpad_state(input, gamepad);
+    if (state == NULL) {
         return;
     }
-    uint8_t event_type;
-    switch (event->type) {
-        case SDL_CONTROLLERTOUCHPADUP: {
-            event_type = LI_TOUCH_EVENT_UP;
-            break;
+
+    controller_touchpad_finger_t *finger = NULL;
+    bool was_active = false;
+    float finger_dx = 0.0f, finger_dy = 0.0f;
+    if (event->finger >= 0 && event->finger < CONTROLLER_TOUCHPAD_TRACKED_FINGERS) {
+        uint8_t finger_bit = (uint8_t) (1u << event->finger);
+        finger = &state->fingers[event->finger];
+        was_active = (state->active_fingers & finger_bit) != 0;
+        if (was_active && event->type == SDL_CONTROLLERTOUCHPADMOTION) {
+            finger_dx = event->x - finger->x;
+            finger_dy = event->y - finger->y;
         }
-        case SDL_CONTROLLERTOUCHPADDOWN: {
-            event_type = LI_TOUCH_EVENT_DOWN;
-            break;
+
+        if (!was_active && event->type != SDL_CONTROLLERTOUCHPADUP) {
+            finger->down_x = event->x;
+            finger->down_y = event->y;
+            finger->down_timestamp = event->timestamp;
         }
-        case SDL_CONTROLLERTOUCHPADMOTION: {
-            event_type = LI_TOUCH_EVENT_MOVE;
-            break;
+        finger->x = event->x;
+        finger->y = event->y;
+
+        if (was_active && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING &&
+            controller_touchpad_finger_exceeded_tap_slop(
+                    finger, CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
+            bool hold_elapsed = event->type == SDL_CONTROLLERTOUCHPADMOTION &&
+                                SDL_TICKS_PASSED(event->timestamp,
+                                                 finger->down_timestamp + CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS);
+            if (hold_elapsed) {
+                state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD;
+                LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
+            } else {
+                controller_touchpad_end_tap(state);
+            }
         }
-        default: {
+
+        if (was_active && state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING &&
+            controller_touchpad_finger_exceeded_tap_slop(
+                    finger, CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ)) {
+            controller_touchpad_end_tap(state);
+        }
+
+        if (event->type == SDL_CONTROLLERTOUCHPADUP) {
+            state->active_fingers &= (uint8_t) ~finger_bit;
+        } else {
+            state->active_fingers |= finger_bit;
+        }
+    } else if (event->type == SDL_CONTROLLERTOUCHPADDOWN) {
+        controller_touchpad_end_tap(state);
+    }
+
+    bool two_fingers = state->active_fingers == 0x3u;
+    if (event->type == SDL_CONTROLLERTOUCHPADDOWN) {
+        if (two_fingers) {
+            controller_touchpad_end_tap(state);
+
+            // Don't delay scrolling/pointer motion for a two-finger tap when
+            // the configured secondary action cannot produce a click.
+            if (input->controller_touchpad_secondary_button != 0) {
+                uint32_t t0 = state->fingers[0].down_timestamp;
+                uint32_t t1 = state->fingers[1].down_timestamp;
+                uint32_t chord_delta = t0 >= t1 ? t0 - t1 : t1 - t0;
+                bool within_slop =
+                        !controller_touchpad_finger_exceeded_tap_slop(
+                                &state->fingers[0], CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ) &&
+                        !controller_touchpad_finger_exceeded_tap_slop(
+                                &state->fingers[1], CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ);
+                if (chord_delta <= CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_CHORD_MS && within_slop) {
+                    state->tap_state = CONTROLLER_TOUCHPAD_TAP_TWO_PENDING;
+                }
+            }
+        } else if (state->active_fingers != 0 && input->controller_touchpad_tap_to_click &&
+                   finger != NULL && state->physical_mouse_button == 0) {
+            state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING;
+        }
+    } else if (event->type == SDL_CONTROLLERTOUCHPADUP) {
+        if (finger != NULL && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD) {
+            controller_touchpad_end_tap(state);
+        } else if (finger != NULL && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING) {
+            if (event->timestamp - finger->down_timestamp <= CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS) {
+                controller_touchpad_send_mouse_click(BUTTON_LEFT);
+            }
+            controller_touchpad_end_tap(state);
+        }
+
+        if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING && state->active_fingers == 0) {
+            uint32_t tap_start = state->fingers[0].down_timestamp < state->fingers[1].down_timestamp
+                                 ? state->fingers[0].down_timestamp
+                                 : state->fingers[1].down_timestamp;
+            if (event->timestamp - tap_start <= CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS) {
+                controller_touchpad_send_mouse_click(input->controller_touchpad_secondary_button);
+            }
+            controller_touchpad_end_tap(state);
+        }
+    }
+
+    // Keep pointer/scroll motion quiet until a two-finger tap either completes
+    // or exceeds its movement threshold.
+    if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING && state->active_fingers != 0) {
+        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        return;
+    }
+
+    if (input->controller_touchpad_two_finger_scroll && two_fingers) {
+        if (state->motion_state != CONTROLLER_TOUCHPAD_MOTION_SCROLL ||
+            event->type != SDL_CONTROLLERTOUCHPADMOTION) {
+            state->motion_state = CONTROLLER_TOUCHPAD_MOTION_SCROLL;
+            state->motion_remainder_x = 0.0f;
+            state->motion_remainder_y = 0.0f;
             return;
         }
+
+        // Each SDL event reports one contact's movement. Halving each
+        // contribution makes the shared accumulator track the two-finger
+        // centroid instead of summing both contacts and doubling sensitivity.
+        state->motion_remainder_x += finger_dx * 0.5f * input->controller_touchpad_scroll_scale;
+        state->motion_remainder_y += finger_dy * 0.5f * input->controller_touchpad_scroll_scale;
+
+        short scroll_x = controller_touchpad_take_delta(&state->motion_remainder_x);
+        short scroll_y = controller_touchpad_take_delta(&state->motion_remainder_y);
+        if (scroll_y != 0) {
+            LiSendHighResScrollEvent(scroll_y);
+        }
+        if (scroll_x != 0) {
+            LiSendHighResHScrollEvent(scroll_x);
+        }
+        return;
     }
-    LiSendControllerTouchEvent(gamepad->gs_id, event_type, event->finger, event->x, event->y, event->pressure);
+
+    if (state->motion_state == CONTROLLER_TOUCHPAD_MOTION_SCROLL) {
+        // Keep the pointer frozen until every finger from the scroll gesture is up.
+        if (state->active_fingers != 0) {
+            return;
+        }
+
+        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        state->motion_remainder_x = 0.0f;
+        state->motion_remainder_y = 0.0f;
+        return;
+    }
+
+    int primary_finger = controller_touchpad_primary_finger(state);
+    if (primary_finger < 0) {
+        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        return;
+    }
+
+    uint8_t pointer_state = (uint8_t) (CONTROLLER_TOUCHPAD_MOTION_POINTER_0 + primary_finger);
+    if (state->motion_state != pointer_state || event->type != SDL_CONTROLLERTOUCHPADMOTION) {
+        state->motion_state = pointer_state;
+        state->motion_remainder_x = 0.0f;
+        state->motion_remainder_y = 0.0f;
+        return;
+    }
+
+    if (event->finger != primary_finger) {
+        return;
+    }
+
+    state->motion_remainder_x += finger_dx * input->controller_touchpad_mouse_scale_x;
+    state->motion_remainder_y += finger_dy * input->controller_touchpad_mouse_scale_y;
+
+    short dx = controller_touchpad_take_delta(&state->motion_remainder_x);
+    short dy = controller_touchpad_take_delta(&state->motion_remainder_y);
+    if (dx != 0 || dy != 0) {
+        LiSendMouseMoveEvent(dx, dy);
+    }
+}
+
+void stream_input_update_controller_touchpad_tap_hold(stream_input_t *input) {
+    uint32_t timestamp = SDL_GetTicks();
+    for (short i = 0; i < input->controller_touchpad_count; ++i) {
+        session_input_controller_touchpad_t *state = &input->controller_touchpads[i];
+        if (state->tap_state != CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING) {
+            continue;
+        }
+        int primary_finger = controller_touchpad_primary_finger(state);
+        if (primary_finger < 0) {
+            controller_touchpad_end_tap(state);
+            continue;
+        }
+
+        const controller_touchpad_finger_t *finger = &state->fingers[primary_finger];
+        if (controller_touchpad_finger_exceeded_tap_slop(
+                    finger, CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
+            controller_touchpad_end_tap(state);
+            continue;
+        }
+
+        if (SDL_TICKS_PASSED(
+                    timestamp,
+                    finger->down_timestamp + CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS)) {
+            state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD;
+            LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
+        }
+    }
 }
 
 void stream_input_handle_cdevice(stream_input_t *input, const SDL_ControllerDeviceEvent *event) {
@@ -297,13 +619,18 @@ void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_s
         case SDL_CONTROLLER_TYPE_PS4:
         case SDL_CONTROLLER_TYPE_PS5: {
             type = LI_CTYPE_PS;
-            capabilities |= LI_CCAP_TOUCHPAD;
-            commons_log_info("Input", "  controller capability: touchpad");
             break;
         }
         default: {
             break;
         }
+    }
+    bool advertise_touchpad =
+            input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE &&
+            controller_has_touchpad(gamepad);
+    if (advertise_touchpad) {
+        capabilities |= LI_CCAP_TOUCHPAD;
+        commons_log_info("Input", "  controller capability: touchpad");
     }
 #if SDL_VERSION_ATLEAST(2, 0, 18)
     if (SDL_GameControllerHasRumble(gamepad->controller)) {
@@ -334,7 +661,92 @@ void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_s
         commons_log_info("Input", "  controller capability: RGB LED");
     }
 #endif
-    LiSendControllerArrivalEvent(gamepad->gs_id, input->input->activeGamepadMask, type, 0xFFFFFFFF, capabilities);
+    uint32_t supported_buttons = 0xFFFFFFFFu;
+    if (!advertise_touchpad) {
+        supported_buttons &= ~(uint32_t) TOUCHPAD_FLAG;
+    }
+    LiSendControllerArrivalEvent(gamepad->gs_id, input->input->activeGamepadMask, type,
+                                 supported_buttons, capabilities);
+}
+
+static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state) {
+    return state->active_fingers & 1u ? 0 : (state->active_fingers & 2u ? 1 : -1);
+}
+
+static bool controller_touchpad_lower_right_press(const session_input_controller_touchpad_t *state) {
+    int primary_finger = controller_touchpad_primary_finger(state);
+    if (primary_finger < 0) {
+        return false;
+    }
+
+    const controller_touchpad_finger_t *finger = &state->fingers[primary_finger];
+    return finger->x >= CONTROLLER_TOUCHPAD_SECONDARY_CORNER &&
+           finger->y >= CONTROLLER_TOUCHPAD_SECONDARY_CORNER;
+}
+
+static bool controller_touchpad_finger_exceeded_tap_slop(
+        const controller_touchpad_finger_t *finger, float threshold_squared) {
+    float dx = finger->x - finger->down_x;
+    float dy = finger->y - finger->down_y;
+    return dx * dx + dy * dy > threshold_squared;
+}
+
+static void controller_touchpad_end_tap(session_input_controller_touchpad_t *state) {
+    if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD) {
+        LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
+    }
+    state->tap_state = CONTROLLER_TOUCHPAD_TAP_NONE;
+}
+
+static void controller_touchpad_send_mouse_click(int mouse_button) {
+    if (mouse_button == 0) {
+        return;
+    }
+    LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, mouse_button);
+    LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, mouse_button);
+}
+
+static short controller_touchpad_take_delta(float *remainder) {
+    // SDL touch coordinates are normalized, so scaled per-event deltas stay
+    // comfortably within Limelight's signed 16-bit mouse/scroll range.
+    short result = (short) *remainder;
+    *remainder -= (float) result;
+    return result;
+}
+
+static session_input_controller_touchpad_t *controller_touchpad_state(
+        stream_input_t *input, const app_gamepad_state_t *gamepad) {
+    if (input->controller_touchpads == NULL || gamepad->gs_id < 0 ||
+        gamepad->gs_id >= input->controller_touchpad_count) {
+        return NULL;
+    }
+    return &input->controller_touchpads[gamepad->gs_id];
+}
+
+static void controller_touchpad_reset_state(session_input_controller_touchpad_t *state) {
+    controller_touchpad_end_tap(state);
+    if (state->physical_mouse_button > 0) {
+        LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, state->physical_mouse_button);
+    }
+    SDL_memset(state, 0, sizeof(*state));
+}
+
+static bool controller_has_touchpad(const app_gamepad_state_t *gamepad) {
+    if (gamepad->controller == NULL) {
+        return false;
+    }
+
+    SDL_GameControllerType controller_type = SDL_GameControllerGetType(gamepad->controller);
+    if (controller_type == SDL_CONTROLLER_TYPE_PS4 ||
+        controller_type == SDL_CONTROLLER_TYPE_PS5) {
+        return true;
+    }
+
+#if SDL_VERSION_ATLEAST(2, 0, 14)
+    return SDL_GameControllerGetNumTouchpads(gamepad->controller) > 0;
+#else
+    return false;
+#endif
 }
 
 static void release_buttons(stream_input_t *input, app_gamepad_state_t *gamepad) {

--- a/src/app/stream/input/session_gamepad.c
+++ b/src/app/stream/input/session_gamepad.c
@@ -15,35 +15,35 @@
 #define QUIT_BUTTONS (PLAY_FLAG | BACK_FLAG | LB_FLAG | RB_FLAG)
 #define GAMEPAD_COMBO_VMOUSE (LB_FLAG | RS_CLK_FLAG)
 
-#define CONTROLLER_TOUCHPAD_SECONDARY_CORNER 0.75f
-#define CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS 300u
-#define CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ (0.015f * 0.015f)
-#define CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_CHORD_MS 160u
-#define CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ (0.035f * 0.035f)
-#define CONTROLLER_TOUCHPAD_TRACKED_FINGERS 2
+#define TOUCHPAD_SECONDARY_CORNER 0.75f
+#define TOUCHPAD_TAP_THRESHOLD_MS 300u
+#define TOUCHPAD_SINGLE_TAP_SLOP_SQ (0.015f * 0.015f)
+#define TOUCHPAD_TWO_FINGER_TAP_CHORD_MS 160u
+#define TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ (0.035f * 0.035f)
+#define TOUCHPAD_TRACKED_FINGERS 2
 
 enum {
-    CONTROLLER_TOUCHPAD_TAP_NONE = 0,
-    CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING,
-    CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD,
-    CONTROLLER_TOUCHPAD_TAP_TWO_PENDING,
+    TOUCHPAD_TAP_NONE = 0,
+    TOUCHPAD_TAP_SINGLE_PENDING,
+    TOUCHPAD_TAP_SINGLE_HOLD,
+    TOUCHPAD_TAP_TWO_PENDING,
 };
 
 enum {
-    CONTROLLER_TOUCHPAD_MOTION_NONE = 0,
-    CONTROLLER_TOUCHPAD_MOTION_SCROLL,
-    CONTROLLER_TOUCHPAD_MOTION_POINTER_0,
-    CONTROLLER_TOUCHPAD_MOTION_POINTER_1,
+    TOUCHPAD_MOTION_NONE = 0,
+    TOUCHPAD_MOTION_SCROLL,
+    TOUCHPAD_MOTION_POINTER_0,
+    TOUCHPAD_MOTION_POINTER_1,
 };
 
-typedef struct controller_touchpad_finger_t {
+typedef struct touchpad_finger_t {
     float x, y;
     float down_x, down_y;
     uint32_t down_timestamp;
-} controller_touchpad_finger_t;
+} touchpad_finger_t;
 
-struct session_input_controller_touchpad_t {
-    controller_touchpad_finger_t fingers[CONTROLLER_TOUCHPAD_TRACKED_FINGERS];
+struct session_input_touchpad_t {
+    touchpad_finger_t fingers[TOUCHPAD_TRACKED_FINGERS];
     uint8_t active_fingers;
     float motion_remainder_x, motion_remainder_y;
     int8_t physical_mouse_button;
@@ -65,33 +65,33 @@ static bool vmouse_intercepted(stream_input_t *input, const app_gamepad_state_t 
 
 static bool filter_deadzone_2axis(stream_input_t *input, short *x, short *y);
 
-static session_input_controller_touchpad_t *controller_touchpad_state(
+static session_input_touchpad_t *touchpad_state(
         stream_input_t *input, const app_gamepad_state_t *gamepad);
 
-static void controller_touchpad_reset_state(session_input_controller_touchpad_t *state);
+static void touchpad_reset_state(session_input_touchpad_t *state);
 
 static bool controller_has_touchpad(const app_gamepad_state_t *gamepad);
 
-static bool controller_touchpad_multitouch(const stream_input_t *input, const app_gamepad_state_t *gamepad);
+static bool touchpad_multitouch_enabled(const stream_input_t *input, const app_gamepad_state_t *gamepad);
 
-static float controller_touchpad_aspect(const app_gamepad_state_t *gamepad);
+static float touchpad_aspect(const app_gamepad_state_t *gamepad);
 
-static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state);
+static int touchpad_primary_finger(const session_input_touchpad_t *state);
 
-static bool controller_touchpad_lower_right_press(const session_input_controller_touchpad_t *state);
+static bool touchpad_lower_right_press(const session_input_touchpad_t *state);
 
-static bool controller_touchpad_finger_exceeded_tap_slop(
-        const controller_touchpad_finger_t *finger, float threshold_squared);
+static bool touchpad_finger_exceeded_tap_slop(
+        const touchpad_finger_t *finger, float threshold_squared);
 
-static void controller_touchpad_end_tap(session_input_controller_touchpad_t *state);
+static void touchpad_end_tap(session_input_touchpad_t *state);
 
-static void controller_touchpad_send_mouse_click(int mouse_button);
+static void touchpad_send_mouse_click(int mouse_button);
 
-static short controller_touchpad_take_delta(float *remainder);
+static short touchpad_take_delta(float *remainder);
 
-void stream_input_controller_touchpad_mouse_init(stream_input_t *input) {
-    if (input->controller_touchpads != NULL ||
-        input->controller_touchpad_mode != CONTROLLER_TOUCHPAD_MODE_MOUSE) {
+void stream_input_touchpad_mouse_init(stream_input_t *input) {
+    if (input->touchpads != NULL ||
+        input->touchpad_mode != TOUCHPAD_MODE_MOUSE) {
         return;
     }
 
@@ -100,21 +100,21 @@ void stream_input_controller_touchpad_mouse_init(stream_input_t *input) {
         return;
     }
 
-    input->controller_touchpads = SDL_calloc((size_t) count, sizeof(*input->controller_touchpads));
-    if (input->controller_touchpads != NULL) {
-        input->controller_touchpad_count = count;
+    input->touchpads = SDL_calloc((size_t) count, sizeof(*input->touchpads));
+    if (input->touchpads != NULL) {
+        input->touchpad_count = count;
     }
 }
 
-void stream_input_controller_touchpad_mouse_deinit(stream_input_t *input) {
-    if (input->controller_touchpads != NULL) {
-        for (short i = 0; i < input->controller_touchpad_count; ++i) {
-            controller_touchpad_reset_state(&input->controller_touchpads[i]);
+void stream_input_touchpad_mouse_deinit(stream_input_t *input) {
+    if (input->touchpads != NULL) {
+        for (short i = 0; i < input->touchpad_count; ++i) {
+            touchpad_reset_state(&input->touchpads[i]);
         }
-        SDL_free(input->controller_touchpads);
-        input->controller_touchpads = NULL;
+        SDL_free(input->touchpads);
+        input->touchpads = NULL;
     }
-    input->controller_touchpad_count = 0;
+    input->touchpad_count = 0;
 }
 
 void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButtonEvent *event) {
@@ -171,18 +171,18 @@ void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButt
             button = RB_FLAG;
             break;
         case SDL_CONTROLLER_BUTTON_TOUCHPAD:
-            if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_MOUSE) {
+            if (input->touchpad_mode == TOUCHPAD_MODE_MOUSE) {
                 if (input->view_only) {
                     return;
                 }
 
-                session_input_controller_touchpad_t *state = controller_touchpad_state(input, gamepad);
+                session_input_touchpad_t *state = touchpad_state(input, gamepad);
                 int mouse_button = BUTTON_LEFT;
                 if (event->type == SDL_CONTROLLERBUTTONDOWN) {
                     if (state != NULL) {
                         // A physical click always wins over a tap gesture or drag.
-                        controller_touchpad_end_tap(state);
-                        if (controller_touchpad_lower_right_press(state)) {
+                        touchpad_end_tap(state);
+                        if (touchpad_lower_right_press(state)) {
                             mouse_button = BUTTON_RIGHT;
                         }
                         state->physical_mouse_button = (int8_t) mouse_button;
@@ -357,11 +357,11 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
 
     // Ignoring every contact past the first disables two-finger gestures wholesale,
     // whether the user turned them off or the pad only tracks one finger.
-    if (event->finger != 0 && !controller_touchpad_multitouch(input, gamepad)) {
+    if (event->finger != 0 && !touchpad_multitouch_enabled(input, gamepad)) {
         return;
     }
 
-    if (input->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_NATIVE) {
+    if (input->touchpad_mode == TOUCHPAD_MODE_NATIVE) {
         uint8_t native_event_type =
                 event->type == SDL_CONTROLLERTOUCHPADDOWN ? LI_TOUCH_EVENT_DOWN :
                 event->type == SDL_CONTROLLERTOUCHPADUP ? LI_TOUCH_EVENT_UP :
@@ -371,15 +371,15 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         return;
     }
 
-    session_input_controller_touchpad_t *state = controller_touchpad_state(input, gamepad);
+    session_input_touchpad_t *state = touchpad_state(input, gamepad);
     if (state == NULL) {
         return;
     }
 
-    controller_touchpad_finger_t *finger = NULL;
+    touchpad_finger_t *finger = NULL;
     bool was_active = false;
     float finger_dx = 0.0f, finger_dy = 0.0f;
-    if (event->finger >= 0 && event->finger < CONTROLLER_TOUCHPAD_TRACKED_FINGERS) {
+    if (event->finger >= 0 && event->finger < TOUCHPAD_TRACKED_FINGERS) {
         uint8_t finger_bit = (uint8_t) (1u << event->finger);
         finger = &state->fingers[event->finger];
         was_active = (state->active_fingers & finger_bit) != 0;
@@ -396,24 +396,24 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         finger->x = event->x;
         finger->y = event->y;
 
-        if (was_active && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING &&
-            controller_touchpad_finger_exceeded_tap_slop(
-                    finger, CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
+        if (was_active && state->tap_state == TOUCHPAD_TAP_SINGLE_PENDING &&
+            touchpad_finger_exceeded_tap_slop(
+                    finger, TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
             bool hold_elapsed = event->type == SDL_CONTROLLERTOUCHPADMOTION &&
                                 SDL_TICKS_PASSED(event->timestamp,
-                                                 finger->down_timestamp + CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS);
+                                                 finger->down_timestamp + TOUCHPAD_TAP_THRESHOLD_MS);
             if (hold_elapsed) {
-                state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD;
+                state->tap_state = TOUCHPAD_TAP_SINGLE_HOLD;
                 LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
             } else {
-                controller_touchpad_end_tap(state);
+                touchpad_end_tap(state);
             }
         }
 
-        if (was_active && state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING &&
-            controller_touchpad_finger_exceeded_tap_slop(
-                    finger, CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ)) {
-            controller_touchpad_end_tap(state);
+        if (was_active && state->tap_state == TOUCHPAD_TAP_TWO_PENDING &&
+            touchpad_finger_exceeded_tap_slop(
+                    finger, TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ)) {
+            touchpad_end_tap(state);
         }
 
         if (event->type == SDL_CONTROLLERTOUCHPADUP) {
@@ -422,62 +422,62 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
             state->active_fingers |= finger_bit;
         }
     } else if (event->type == SDL_CONTROLLERTOUCHPADDOWN) {
-        controller_touchpad_end_tap(state);
+        touchpad_end_tap(state);
     }
 
     bool two_fingers = state->active_fingers == 0x3u;
     if (event->type == SDL_CONTROLLERTOUCHPADDOWN) {
         if (two_fingers) {
-            controller_touchpad_end_tap(state);
+            touchpad_end_tap(state);
 
             {
                 uint32_t t0 = state->fingers[0].down_timestamp;
                 uint32_t t1 = state->fingers[1].down_timestamp;
                 uint32_t chord_delta = t0 >= t1 ? t0 - t1 : t1 - t0;
                 bool within_slop =
-                        !controller_touchpad_finger_exceeded_tap_slop(
-                                &state->fingers[0], CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ) &&
-                        !controller_touchpad_finger_exceeded_tap_slop(
-                                &state->fingers[1], CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ);
-                if (chord_delta <= CONTROLLER_TOUCHPAD_TWO_FINGER_TAP_CHORD_MS && within_slop) {
-                    state->tap_state = CONTROLLER_TOUCHPAD_TAP_TWO_PENDING;
+                        !touchpad_finger_exceeded_tap_slop(
+                                &state->fingers[0], TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ) &&
+                        !touchpad_finger_exceeded_tap_slop(
+                                &state->fingers[1], TOUCHPAD_TWO_FINGER_TAP_SLOP_SQ);
+                if (chord_delta <= TOUCHPAD_TWO_FINGER_TAP_CHORD_MS && within_slop) {
+                    state->tap_state = TOUCHPAD_TAP_TWO_PENDING;
                 }
             }
         } else if (state->active_fingers != 0 && finger != NULL && state->physical_mouse_button == 0) {
-            state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING;
+            state->tap_state = TOUCHPAD_TAP_SINGLE_PENDING;
         }
     } else if (event->type == SDL_CONTROLLERTOUCHPADUP) {
-        if (finger != NULL && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD) {
-            controller_touchpad_end_tap(state);
-        } else if (finger != NULL && state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING) {
-            if (event->timestamp - finger->down_timestamp <= CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS) {
-                controller_touchpad_send_mouse_click(BUTTON_LEFT);
+        if (finger != NULL && state->tap_state == TOUCHPAD_TAP_SINGLE_HOLD) {
+            touchpad_end_tap(state);
+        } else if (finger != NULL && state->tap_state == TOUCHPAD_TAP_SINGLE_PENDING) {
+            if (event->timestamp - finger->down_timestamp <= TOUCHPAD_TAP_THRESHOLD_MS) {
+                touchpad_send_mouse_click(BUTTON_LEFT);
             }
-            controller_touchpad_end_tap(state);
+            touchpad_end_tap(state);
         }
 
-        if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING && state->active_fingers == 0) {
+        if (state->tap_state == TOUCHPAD_TAP_TWO_PENDING && state->active_fingers == 0) {
             uint32_t tap_start = state->fingers[0].down_timestamp < state->fingers[1].down_timestamp
                                  ? state->fingers[0].down_timestamp
                                  : state->fingers[1].down_timestamp;
-            if (event->timestamp - tap_start <= CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS) {
-                controller_touchpad_send_mouse_click(BUTTON_RIGHT);
+            if (event->timestamp - tap_start <= TOUCHPAD_TAP_THRESHOLD_MS) {
+                touchpad_send_mouse_click(BUTTON_RIGHT);
             }
-            controller_touchpad_end_tap(state);
+            touchpad_end_tap(state);
         }
     }
 
     // Keep pointer/scroll motion quiet until a two-finger tap either completes
     // or exceeds its movement threshold.
-    if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_TWO_PENDING && state->active_fingers != 0) {
-        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+    if (state->tap_state == TOUCHPAD_TAP_TWO_PENDING && state->active_fingers != 0) {
+        state->motion_state = TOUCHPAD_MOTION_NONE;
         return;
     }
 
     if (two_fingers) {
-        if (state->motion_state != CONTROLLER_TOUCHPAD_MOTION_SCROLL ||
+        if (state->motion_state != TOUCHPAD_MOTION_SCROLL ||
             event->type != SDL_CONTROLLERTOUCHPADMOTION) {
-            state->motion_state = CONTROLLER_TOUCHPAD_MOTION_SCROLL;
+            state->motion_state = TOUCHPAD_MOTION_SCROLL;
             state->motion_remainder_x = 0.0f;
             state->motion_remainder_y = 0.0f;
             return;
@@ -486,11 +486,11 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         // Each SDL event reports one contact's movement. Halving each
         // contribution makes the shared accumulator track the two-finger
         // centroid instead of summing both contacts and doubling sensitivity.
-        state->motion_remainder_x += finger_dx * 0.5f * input->controller_touchpad_scroll_scale;
-        state->motion_remainder_y += finger_dy * 0.5f * input->controller_touchpad_scroll_scale;
+        state->motion_remainder_x += finger_dx * 0.5f * input->touchpad_scroll_scale;
+        state->motion_remainder_y += finger_dy * 0.5f * input->touchpad_scroll_scale;
 
-        short scroll_x = controller_touchpad_take_delta(&state->motion_remainder_x);
-        short scroll_y = controller_touchpad_take_delta(&state->motion_remainder_y);
+        short scroll_x = touchpad_take_delta(&state->motion_remainder_x);
+        short scroll_y = touchpad_take_delta(&state->motion_remainder_y);
         if (scroll_y != 0) {
             LiSendHighResScrollEvent(scroll_y);
         }
@@ -500,25 +500,25 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         return;
     }
 
-    if (state->motion_state == CONTROLLER_TOUCHPAD_MOTION_SCROLL) {
+    if (state->motion_state == TOUCHPAD_MOTION_SCROLL) {
         // Keep the pointer frozen until every finger from the scroll gesture is up.
         if (state->active_fingers != 0) {
             return;
         }
 
-        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        state->motion_state = TOUCHPAD_MOTION_NONE;
         state->motion_remainder_x = 0.0f;
         state->motion_remainder_y = 0.0f;
         return;
     }
 
-    int primary_finger = controller_touchpad_primary_finger(state);
+    int primary_finger = touchpad_primary_finger(state);
     if (primary_finger < 0) {
-        state->motion_state = CONTROLLER_TOUCHPAD_MOTION_NONE;
+        state->motion_state = TOUCHPAD_MOTION_NONE;
         return;
     }
 
-    uint8_t pointer_state = (uint8_t) (CONTROLLER_TOUCHPAD_MOTION_POINTER_0 + primary_finger);
+    uint8_t pointer_state = (uint8_t) (TOUCHPAD_MOTION_POINTER_0 + primary_finger);
     if (state->motion_state != pointer_state || event->type != SDL_CONTROLLERTOUCHPADMOTION) {
         state->motion_state = pointer_state;
         state->motion_remainder_x = 0.0f;
@@ -530,41 +530,41 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         return;
     }
 
-    float gain = input->controller_touchpad_mouse_gain;
+    float gain = input->touchpad_mouse_gain;
     state->motion_remainder_x += finger_dx * gain;
-    state->motion_remainder_y += finger_dy * gain * controller_touchpad_aspect(gamepad);
+    state->motion_remainder_y += finger_dy * gain * touchpad_aspect(gamepad);
 
-    short dx = controller_touchpad_take_delta(&state->motion_remainder_x);
-    short dy = controller_touchpad_take_delta(&state->motion_remainder_y);
+    short dx = touchpad_take_delta(&state->motion_remainder_x);
+    short dy = touchpad_take_delta(&state->motion_remainder_y);
     if (dx != 0 || dy != 0) {
         LiSendMouseMoveEvent(dx, dy);
     }
 }
 
-void stream_input_update_controller_touchpad_tap_hold(stream_input_t *input) {
+void stream_input_update_touchpad_tap_hold(stream_input_t *input) {
     uint32_t timestamp = SDL_GetTicks();
-    for (short i = 0; i < input->controller_touchpad_count; ++i) {
-        session_input_controller_touchpad_t *state = &input->controller_touchpads[i];
-        if (state->tap_state != CONTROLLER_TOUCHPAD_TAP_SINGLE_PENDING) {
+    for (short i = 0; i < input->touchpad_count; ++i) {
+        session_input_touchpad_t *state = &input->touchpads[i];
+        if (state->tap_state != TOUCHPAD_TAP_SINGLE_PENDING) {
             continue;
         }
-        int primary_finger = controller_touchpad_primary_finger(state);
+        int primary_finger = touchpad_primary_finger(state);
         if (primary_finger < 0) {
-            controller_touchpad_end_tap(state);
+            touchpad_end_tap(state);
             continue;
         }
 
-        const controller_touchpad_finger_t *finger = &state->fingers[primary_finger];
-        if (controller_touchpad_finger_exceeded_tap_slop(
-                    finger, CONTROLLER_TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
-            controller_touchpad_end_tap(state);
+        const touchpad_finger_t *finger = &state->fingers[primary_finger];
+        if (touchpad_finger_exceeded_tap_slop(
+                    finger, TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
+            touchpad_end_tap(state);
             continue;
         }
 
         if (SDL_TICKS_PASSED(
                     timestamp,
-                    finger->down_timestamp + CONTROLLER_TOUCHPAD_TAP_THRESHOLD_MS)) {
-            state->tap_state = CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD;
+                    finger->down_timestamp + TOUCHPAD_TAP_THRESHOLD_MS)) {
+            state->tap_state = TOUCHPAD_TAP_SINGLE_HOLD;
             LiSendMouseButtonEvent(BUTTON_ACTION_PRESS, BUTTON_LEFT);
         }
     }
@@ -649,36 +649,36 @@ void stream_input_send_gamepad_arrive(const stream_input_t *input, app_gamepad_s
                                  0xFFFFFFFF, capabilities);
 }
 
-static int controller_touchpad_primary_finger(const session_input_controller_touchpad_t *state) {
+static int touchpad_primary_finger(const session_input_touchpad_t *state) {
     return state->active_fingers & 1u ? 0 : (state->active_fingers & 2u ? 1 : -1);
 }
 
-static bool controller_touchpad_lower_right_press(const session_input_controller_touchpad_t *state) {
-    int primary_finger = controller_touchpad_primary_finger(state);
+static bool touchpad_lower_right_press(const session_input_touchpad_t *state) {
+    int primary_finger = touchpad_primary_finger(state);
     if (primary_finger < 0) {
         return false;
     }
 
-    const controller_touchpad_finger_t *finger = &state->fingers[primary_finger];
-    return finger->x >= CONTROLLER_TOUCHPAD_SECONDARY_CORNER &&
-           finger->y >= CONTROLLER_TOUCHPAD_SECONDARY_CORNER;
+    const touchpad_finger_t *finger = &state->fingers[primary_finger];
+    return finger->x >= TOUCHPAD_SECONDARY_CORNER &&
+           finger->y >= TOUCHPAD_SECONDARY_CORNER;
 }
 
-static bool controller_touchpad_finger_exceeded_tap_slop(
-        const controller_touchpad_finger_t *finger, float threshold_squared) {
+static bool touchpad_finger_exceeded_tap_slop(
+        const touchpad_finger_t *finger, float threshold_squared) {
     float dx = finger->x - finger->down_x;
     float dy = finger->y - finger->down_y;
     return dx * dx + dy * dy > threshold_squared;
 }
 
-static void controller_touchpad_end_tap(session_input_controller_touchpad_t *state) {
-    if (state->tap_state == CONTROLLER_TOUCHPAD_TAP_SINGLE_HOLD) {
+static void touchpad_end_tap(session_input_touchpad_t *state) {
+    if (state->tap_state == TOUCHPAD_TAP_SINGLE_HOLD) {
         LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
     }
-    state->tap_state = CONTROLLER_TOUCHPAD_TAP_NONE;
+    state->tap_state = TOUCHPAD_TAP_NONE;
 }
 
-static void controller_touchpad_send_mouse_click(int mouse_button) {
+static void touchpad_send_mouse_click(int mouse_button) {
     if (mouse_button == 0) {
         return;
     }
@@ -686,7 +686,7 @@ static void controller_touchpad_send_mouse_click(int mouse_button) {
     LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, mouse_button);
 }
 
-static short controller_touchpad_take_delta(float *remainder) {
+static short touchpad_take_delta(float *remainder) {
     // SDL touch coordinates are normalized, so scaled per-event deltas stay
     // comfortably within Limelight's signed 16-bit mouse/scroll range.
     short result = (short) *remainder;
@@ -694,17 +694,17 @@ static short controller_touchpad_take_delta(float *remainder) {
     return result;
 }
 
-static session_input_controller_touchpad_t *controller_touchpad_state(
+static session_input_touchpad_t *touchpad_state(
         stream_input_t *input, const app_gamepad_state_t *gamepad) {
-    if (input->controller_touchpads == NULL || gamepad->gs_id < 0 ||
-        gamepad->gs_id >= input->controller_touchpad_count) {
+    if (input->touchpads == NULL || gamepad->gs_id < 0 ||
+        gamepad->gs_id >= input->touchpad_count) {
         return NULL;
     }
-    return &input->controller_touchpads[gamepad->gs_id];
+    return &input->touchpads[gamepad->gs_id];
 }
 
-static void controller_touchpad_reset_state(session_input_controller_touchpad_t *state) {
-    controller_touchpad_end_tap(state);
+static void touchpad_reset_state(session_input_touchpad_t *state) {
+    touchpad_end_tap(state);
     if (state->physical_mouse_button > 0) {
         LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, state->physical_mouse_button);
     }
@@ -729,8 +729,8 @@ static bool controller_has_touchpad(const app_gamepad_state_t *gamepad) {
 #endif
 }
 
-static bool controller_touchpad_multitouch(const stream_input_t *input, const app_gamepad_state_t *gamepad) {
-    if (!input->controller_touchpad_multitouch || gamepad->controller == NULL) {
+static bool touchpad_multitouch_enabled(const stream_input_t *input, const app_gamepad_state_t *gamepad) {
+    if (!input->touchpad_multitouch || gamepad->controller == NULL) {
         return false;
     }
 #if SDL_VERSION_ATLEAST(2, 0, 14)
@@ -748,7 +748,7 @@ static bool controller_touchpad_multitouch(const stream_input_t *input, const ap
  * the divisors SDL itself uses -- see TOUCHPAD_SCALEX/TOUCHPAD_SCALEY in
  * SDL_hidapi_ps4.c, SDL_hidapi_ps5.c and SDL_hidapi_shield.c, which are the only
  * drivers that report a touchpad at all. */
-static float controller_touchpad_aspect(const app_gamepad_state_t *gamepad) {
+static float touchpad_aspect(const app_gamepad_state_t *gamepad) {
     if (gamepad->controller != NULL) {
         switch (SDL_GameControllerGetType(gamepad->controller)) {
             case SDL_CONTROLLER_TYPE_PS4:

--- a/src/app/stream/input/session_gamepad.c
+++ b/src/app/stream/input/session_gamepad.c
@@ -32,6 +32,7 @@ enum {
 enum {
     TOUCHPAD_MOTION_NONE = 0,
     TOUCHPAD_MOTION_SCROLL,
+    TOUCHPAD_MOTION_SETTLING,
     TOUCHPAD_MOTION_POINTER_0,
     TOUCHPAD_MOTION_POINTER_1,
 };
@@ -84,6 +85,10 @@ static bool touchpad_finger_exceeded_tap_slop(
         const touchpad_finger_t *finger, float threshold_squared);
 
 static void touchpad_end_tap(session_input_touchpad_t *state);
+
+static void touchpad_begin_settling(session_input_touchpad_t *state);
+
+static bool touchpad_settled(const session_input_touchpad_t *state);
 
 static void touchpad_send_mouse_click(int mouse_button);
 
@@ -182,7 +187,11 @@ void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButt
                     if (state != NULL) {
                         // A physical click always wins over a tap gesture or drag.
                         touchpad_end_tap(state);
-                        if (touchpad_lower_right_press(state)) {
+                        // Two fingers down, or one down in the lower-right corner,
+                        // both mean secondary click -- the two ways a trackpad
+                        // offers a right button without having one.
+                        bool two_finger_press = state->active_fingers == 0x3u;
+                        if (two_finger_press || touchpad_lower_right_press(state)) {
                             mouse_button = BUTTON_RIGHT;
                         }
                         state->physical_mouse_button = (int8_t) mouse_button;
@@ -190,6 +199,13 @@ void stream_input_handle_cbutton(stream_input_t *input, const SDL_ControllerButt
                 } else if (state != NULL) {
                     mouse_button = state->physical_mouse_button > 0 ? state->physical_mouse_button : BUTTON_LEFT;
                     state->physical_mouse_button = 0;
+                }
+                if (state != NULL) {
+                    // Clicking the pad rocks the contacts, and releasing rocks them
+                    // back. Neither is a gesture, so make both settle before any
+                    // movement counts again -- otherwise a click part way through a
+                    // scroll scrolls, and one at rest nudges the cursor.
+                    touchpad_begin_settling(state);
                 }
 
                 LiSendMouseButtonEvent(event->type == SDL_CONTROLLERBUTTONDOWN ?
@@ -467,11 +483,32 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
         }
     }
 
-    // Keep pointer/scroll motion quiet until a two-finger tap either completes
-    // or exceeds its movement threshold.
-    if (state->tap_state == TOUCHPAD_TAP_TWO_PENDING && state->active_fingers != 0) {
+    // A tap is not a movement. Hold the pointer still until the gesture either
+    // completes as a tap or travels far enough to stop being one -- a finger
+    // always rolls a little while pressing, and at any usable speed that is
+    // enough to slide the cursor off whatever the user was aiming at before the
+    // click lands. Movement made while the gesture was still a candidate is
+    // dropped rather than replayed, so the pointer never jumps to catch up.
+    if ((state->tap_state == TOUCHPAD_TAP_SINGLE_PENDING ||
+         state->tap_state == TOUCHPAD_TAP_TWO_PENDING) && state->active_fingers != 0) {
         state->motion_state = TOUCHPAD_MOTION_NONE;
         return;
+    }
+
+    // Anything that disturbs the contacts without being a movement -- pressing the
+    // pad, releasing it, lifting one finger out of a scroll -- parks motion here
+    // until some finger travels far enough to be deliberate. Whatever gesture is
+    // appropriate then resumes on its own, so a press mid-scroll neither scrolls
+    // nor jumps the cursor, and press-and-drag still works.
+    if (state->motion_state == TOUCHPAD_MOTION_SETTLING) {
+        if (state->active_fingers == 0) {
+            state->motion_state = TOUCHPAD_MOTION_NONE;
+            return;
+        }
+        if (!touchpad_settled(state)) {
+            return;
+        }
+        state->motion_state = TOUCHPAD_MOTION_NONE;
     }
 
     if (two_fingers) {
@@ -501,14 +538,16 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
     }
 
     if (state->motion_state == TOUCHPAD_MOTION_SCROLL) {
-        // Keep the pointer frozen until every finger from the scroll gesture is up.
-        if (state->active_fingers != 0) {
+        if (state->active_fingers == 0) {
+            state->motion_state = TOUCHPAD_MOTION_NONE;
+            state->motion_remainder_x = 0.0f;
+            state->motion_remainder_y = 0.0f;
             return;
         }
-
-        state->motion_state = TOUCHPAD_MOTION_NONE;
-        state->motion_remainder_x = 0.0f;
-        state->motion_remainder_y = 0.0f;
+        // A finger of the scroll is still down. Hand the pointer back to it, but
+        // only once it moves with intent: fingers come off a scroll one at a time
+        // and the trailing one always slides a little on its way up.
+        touchpad_begin_settling(state);
         return;
     }
 
@@ -676,6 +715,28 @@ static void touchpad_end_tap(session_input_touchpad_t *state) {
         LiSendMouseButtonEvent(BUTTON_ACTION_RELEASE, BUTTON_LEFT);
     }
     state->tap_state = TOUCHPAD_TAP_NONE;
+}
+
+static void touchpad_begin_settling(session_input_touchpad_t *state) {
+    for (int i = 0; i < TOUCHPAD_TRACKED_FINGERS; ++i) {
+        if (state->active_fingers & (1u << i)) {
+            state->fingers[i].down_x = state->fingers[i].x;
+            state->fingers[i].down_y = state->fingers[i].y;
+        }
+    }
+    state->motion_state = TOUCHPAD_MOTION_SETTLING;
+    state->motion_remainder_x = 0.0f;
+    state->motion_remainder_y = 0.0f;
+}
+
+static bool touchpad_settled(const session_input_touchpad_t *state) {
+    for (int i = 0; i < TOUCHPAD_TRACKED_FINGERS; ++i) {
+        if ((state->active_fingers & (1u << i)) &&
+            touchpad_finger_exceeded_tap_slop(&state->fingers[i], TOUCHPAD_SINGLE_TAP_SLOP_SQ)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 static void touchpad_send_mouse_click(int mouse_button) {

--- a/src/app/stream/input/session_input.c
+++ b/src/app/stream/input/session_input.c
@@ -25,11 +25,6 @@
 #define CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT 9.0f
 #define CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE 600.0f
 
-static uint8_t controller_touchpad_mouse_button(int press) {
-    static const uint8_t buttons[] = {0, BUTTON_LEFT, BUTTON_RIGHT, BUTTON_MIDDLE};
-    return (unsigned int) press < sizeof(buttons) / sizeof(buttons[0]) ? buttons[press] : 0;
-}
-
 void session_input_init(stream_input_t *input, session_t *session, app_input_t *app_input,
                         const session_config_t *config) {
     input->session = session;
@@ -38,17 +33,12 @@ void session_input_init(stream_input_t *input, session_t *session, app_input_t *
     input->stick_deadzone = config->stick_deadzone;
     input->no_sdl_mouse = config->hardware_mouse;
     input->controller_touchpad_mode = (uint8_t) config->controller_touchpad_mode;
-    input->controller_touchpad_press_button =
-            controller_touchpad_mouse_button(config->controller_touchpad_press);
-    input->controller_touchpad_secondary_button =
-            controller_touchpad_mouse_button(config->controller_touchpad_secondary_click);
-    input->controller_touchpad_tap_to_click = config->controller_touchpad_tap_to_click;
-    input->controller_touchpad_two_finger_scroll = config->controller_touchpad_two_finger_scroll;
+    input->controller_touchpad_multitouch = config->controller_touchpad_multitouch;
     input->controller_touchpad_mouse_scale_x = CONTROLLER_TOUCHPAD_MOUSE_SCALE_X_PERCENT *
                                                (float) config->controller_touchpad_sensitivity;
     input->controller_touchpad_mouse_scale_y = CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT *
                                                (float) config->controller_touchpad_sensitivity;
-    input->controller_touchpad_scroll_scale = config->controller_touchpad_invert_two_finger_scroll
+    input->controller_touchpad_scroll_scale = config->controller_touchpad_natural_scroll
                                               ? CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE
                                               : -CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE;
     input->controller_touchpads = NULL;

--- a/src/app/stream/input/session_input.c
+++ b/src/app/stream/input/session_input.c
@@ -21,8 +21,11 @@
 #include "stream/session_priv.h"
 #include "session_evmouse.h"
 
-#define CONTROLLER_TOUCHPAD_MOUSE_SCALE_X_PERCENT 16.0f
-#define CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT 9.0f
+/* Pointer travel, in host pixels, for a finger swept across the full width of the
+ * touchpad at 100% sensitivity. Vertical travel is derived from each pad's own
+ * aspect ratio at motion time, so a given physical movement feels the same on
+ * both axes regardless of which controller it came from. */
+#define CONTROLLER_TOUCHPAD_MOUSE_BASE_SPEED 16.0f
 #define CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE 600.0f
 
 void session_input_init(stream_input_t *input, session_t *session, app_input_t *app_input,
@@ -34,10 +37,8 @@ void session_input_init(stream_input_t *input, session_t *session, app_input_t *
     input->no_sdl_mouse = config->hardware_mouse;
     input->controller_touchpad_mode = (uint8_t) config->controller_touchpad_mode;
     input->controller_touchpad_multitouch = config->controller_touchpad_multitouch;
-    input->controller_touchpad_mouse_scale_x = CONTROLLER_TOUCHPAD_MOUSE_SCALE_X_PERCENT *
-                                               (float) config->controller_touchpad_sensitivity;
-    input->controller_touchpad_mouse_scale_y = CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT *
-                                               (float) config->controller_touchpad_sensitivity;
+    input->controller_touchpad_mouse_gain = CONTROLLER_TOUCHPAD_MOUSE_BASE_SPEED *
+                                            (float) config->controller_touchpad_sensitivity;
     input->controller_touchpad_scroll_scale = config->controller_touchpad_natural_scroll
                                               ? CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE
                                               : -CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE;

--- a/src/app/stream/input/session_input.c
+++ b/src/app/stream/input/session_input.c
@@ -25,8 +25,8 @@
  * touchpad at 100% sensitivity. Vertical travel is derived from each pad's own
  * aspect ratio at motion time, so a given physical movement feels the same on
  * both axes regardless of which controller it came from. */
-#define CONTROLLER_TOUCHPAD_MOUSE_BASE_SPEED 16.0f
-#define CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE 600.0f
+#define TOUCHPAD_MOUSE_BASE_SPEED 16.0f
+#define TOUCHPAD_SCROLL_FINGER_SCALE 600.0f
 
 void session_input_init(stream_input_t *input, session_t *session, app_input_t *app_input,
                         const session_config_t *config) {
@@ -35,15 +35,15 @@ void session_input_init(stream_input_t *input, session_t *session, app_input_t *
     input->view_only = config->view_only;
     input->stick_deadzone = config->stick_deadzone;
     input->no_sdl_mouse = config->hardware_mouse;
-    input->controller_touchpad_mode = (uint8_t) config->controller_touchpad_mode;
-    input->controller_touchpad_multitouch = config->controller_touchpad_multitouch;
-    input->controller_touchpad_mouse_gain = CONTROLLER_TOUCHPAD_MOUSE_BASE_SPEED *
-                                            (float) config->controller_touchpad_sensitivity;
-    input->controller_touchpad_scroll_scale = config->controller_touchpad_natural_scroll
-                                              ? CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE
-                                              : -CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE;
-    input->controller_touchpads = NULL;
-    input->controller_touchpad_count = 0;
+    input->touchpad_mode = (uint8_t) config->touchpad_mode;
+    input->touchpad_multitouch = config->touchpad_multitouch;
+    input->touchpad_mouse_gain = TOUCHPAD_MOUSE_BASE_SPEED *
+                                            (float) config->touchpad_speed;
+    input->touchpad_scroll_scale = config->touchpad_natural_scroll
+                                              ? TOUCHPAD_SCROLL_FINGER_SCALE
+                                              : -TOUCHPAD_SCROLL_FINGER_SCALE;
+    input->touchpads = NULL;
+    input->touchpad_count = 0;
 #if FEATURE_INPUT_EVMOUSE
     if (!config->view_only && config->hardware_mouse) {
         session_evmouse_init(&input->evmouse, session);
@@ -52,7 +52,7 @@ void session_input_init(stream_input_t *input, session_t *session, app_input_t *
 }
 
 void session_input_deinit(stream_input_t *input) {
-    stream_input_controller_touchpad_mouse_deinit(input);
+    stream_input_touchpad_mouse_deinit(input);
 #if FEATURE_INPUT_EVMOUSE
     const session_config_t *config = &input->session->config;
     if (!config->view_only && config->hardware_mouse) {
@@ -73,7 +73,7 @@ void session_input_interrupt(stream_input_t *input) {
 void session_input_started(stream_input_t *input) {
     input->started = true;
     if (!input->view_only) {
-        stream_input_controller_touchpad_mouse_init(input);
+        stream_input_touchpad_mouse_init(input);
     }
     for (int i = 0, j = app_input_get_max_gamepads(input->input); i < j; ++i) {
         app_gamepad_state_t *gamepad = app_input_gamepad_state_by_index(input->input, i);
@@ -86,7 +86,7 @@ void session_input_started(stream_input_t *input) {
 
 void session_input_stopped(stream_input_t *input) {
     input->started = false;
-    stream_input_controller_touchpad_mouse_deinit(input);
+    stream_input_touchpad_mouse_deinit(input);
 }
 
 void session_input_screen_keyboard_opened(stream_input_t *input) {

--- a/src/app/stream/input/session_input.c
+++ b/src/app/stream/input/session_input.c
@@ -21,6 +21,15 @@
 #include "stream/session_priv.h"
 #include "session_evmouse.h"
 
+#define CONTROLLER_TOUCHPAD_MOUSE_SCALE_X_PERCENT 16.0f
+#define CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT 9.0f
+#define CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE 600.0f
+
+static uint8_t controller_touchpad_mouse_button(int press) {
+    static const uint8_t buttons[] = {0, BUTTON_LEFT, BUTTON_RIGHT, BUTTON_MIDDLE};
+    return (unsigned int) press < sizeof(buttons) / sizeof(buttons[0]) ? buttons[press] : 0;
+}
+
 void session_input_init(stream_input_t *input, session_t *session, app_input_t *app_input,
                         const session_config_t *config) {
     input->session = session;
@@ -28,6 +37,22 @@ void session_input_init(stream_input_t *input, session_t *session, app_input_t *
     input->view_only = config->view_only;
     input->stick_deadzone = config->stick_deadzone;
     input->no_sdl_mouse = config->hardware_mouse;
+    input->controller_touchpad_mode = (uint8_t) config->controller_touchpad_mode;
+    input->controller_touchpad_press_button =
+            controller_touchpad_mouse_button(config->controller_touchpad_press);
+    input->controller_touchpad_secondary_button =
+            controller_touchpad_mouse_button(config->controller_touchpad_secondary_click);
+    input->controller_touchpad_tap_to_click = config->controller_touchpad_tap_to_click;
+    input->controller_touchpad_two_finger_scroll = config->controller_touchpad_two_finger_scroll;
+    input->controller_touchpad_mouse_scale_x = CONTROLLER_TOUCHPAD_MOUSE_SCALE_X_PERCENT *
+                                               (float) config->controller_touchpad_sensitivity;
+    input->controller_touchpad_mouse_scale_y = CONTROLLER_TOUCHPAD_MOUSE_SCALE_Y_PERCENT *
+                                               (float) config->controller_touchpad_sensitivity;
+    input->controller_touchpad_scroll_scale = config->controller_touchpad_invert_two_finger_scroll
+                                              ? CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE
+                                              : -CONTROLLER_TOUCHPAD_SCROLL_FINGER_SCALE;
+    input->controller_touchpads = NULL;
+    input->controller_touchpad_count = 0;
 #if FEATURE_INPUT_EVMOUSE
     if (!config->view_only && config->hardware_mouse) {
         session_evmouse_init(&input->evmouse, session);
@@ -36,6 +61,7 @@ void session_input_init(stream_input_t *input, session_t *session, app_input_t *
 }
 
 void session_input_deinit(stream_input_t *input) {
+    stream_input_controller_touchpad_mouse_deinit(input);
 #if FEATURE_INPUT_EVMOUSE
     const session_config_t *config = &input->session->config;
     if (!config->view_only && config->hardware_mouse) {
@@ -55,6 +81,9 @@ void session_input_interrupt(stream_input_t *input) {
 
 void session_input_started(stream_input_t *input) {
     input->started = true;
+    if (!input->view_only) {
+        stream_input_controller_touchpad_mouse_init(input);
+    }
     for (int i = 0, j = app_input_get_max_gamepads(input->input); i < j; ++i) {
         app_gamepad_state_t *gamepad = app_input_gamepad_state_by_index(input->input, i);
         if (gamepad == NULL) {
@@ -66,6 +95,7 @@ void session_input_started(stream_input_t *input) {
 
 void session_input_stopped(stream_input_t *input) {
     input->started = false;
+    stream_input_controller_touchpad_mouse_deinit(input);
 }
 
 void session_input_screen_keyboard_opened(stream_input_t *input) {

--- a/src/app/stream/input/session_input.h
+++ b/src/app/stream/input/session_input.h
@@ -18,6 +18,8 @@ typedef struct app_input_t app_input_t;
 typedef struct session_config_t session_config_t;
 typedef struct session_t session_t;
 
+typedef struct session_input_controller_touchpad_t session_input_controller_touchpad_t;
+
 typedef struct session_input_vmouse_t {
     struct {
         bool active;
@@ -34,7 +36,17 @@ typedef struct stream_input_t {
     bool started;
     bool view_only, no_sdl_mouse;
     uint8_t stick_deadzone;
+    uint8_t controller_touchpad_mode;
+    uint8_t controller_touchpad_press_button;
+    uint8_t controller_touchpad_secondary_button;
+    bool controller_touchpad_tap_to_click;
+    bool controller_touchpad_two_finger_scroll;
+    short controller_touchpad_count;
+    float controller_touchpad_mouse_scale_x;
+    float controller_touchpad_mouse_scale_y;
+    float controller_touchpad_scroll_scale;
     session_input_vmouse_t vmouse;
+    session_input_controller_touchpad_t *controller_touchpads;
 #if FEATURE_INPUT_EVMOUSE
     session_evmouse_t evmouse;
 #endif
@@ -50,6 +62,10 @@ void session_input_interrupt(stream_input_t *input);
 void session_input_started(stream_input_t *input);
 
 void session_input_stopped(stream_input_t *input);
+
+void stream_input_controller_touchpad_mouse_init(stream_input_t *input);
+
+void stream_input_controller_touchpad_mouse_deinit(stream_input_t *input);
 
 void session_input_screen_keyboard_opened(stream_input_t *input);
 
@@ -70,6 +86,8 @@ void stream_input_handle_csensor(stream_input_t *input, const SDL_ControllerSens
 void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTouchpadEvent *event);
 
 void stream_input_handle_cdevice(stream_input_t *input, const SDL_ControllerDeviceEvent *event);
+
+void stream_input_update_controller_touchpad_tap_hold(stream_input_t *input);
 
 void stream_input_handle_mmotion(stream_input_t *input, const SDL_MouseMotionEvent *event, bool hw_mouse);
 

--- a/src/app/stream/input/session_input.h
+++ b/src/app/stream/input/session_input.h
@@ -37,10 +37,7 @@ typedef struct stream_input_t {
     bool view_only, no_sdl_mouse;
     uint8_t stick_deadzone;
     uint8_t controller_touchpad_mode;
-    uint8_t controller_touchpad_press_button;
-    uint8_t controller_touchpad_secondary_button;
-    bool controller_touchpad_tap_to_click;
-    bool controller_touchpad_two_finger_scroll;
+    bool controller_touchpad_multitouch;
     short controller_touchpad_count;
     float controller_touchpad_mouse_scale_x;
     float controller_touchpad_mouse_scale_y;

--- a/src/app/stream/input/session_input.h
+++ b/src/app/stream/input/session_input.h
@@ -39,8 +39,7 @@ typedef struct stream_input_t {
     uint8_t controller_touchpad_mode;
     bool controller_touchpad_multitouch;
     short controller_touchpad_count;
-    float controller_touchpad_mouse_scale_x;
-    float controller_touchpad_mouse_scale_y;
+    float controller_touchpad_mouse_gain;
     float controller_touchpad_scroll_scale;
     session_input_vmouse_t vmouse;
     session_input_controller_touchpad_t *controller_touchpads;

--- a/src/app/stream/input/session_input.h
+++ b/src/app/stream/input/session_input.h
@@ -18,7 +18,7 @@ typedef struct app_input_t app_input_t;
 typedef struct session_config_t session_config_t;
 typedef struct session_t session_t;
 
-typedef struct session_input_controller_touchpad_t session_input_controller_touchpad_t;
+typedef struct session_input_touchpad_t session_input_touchpad_t;
 
 typedef struct session_input_vmouse_t {
     struct {
@@ -36,13 +36,13 @@ typedef struct stream_input_t {
     bool started;
     bool view_only, no_sdl_mouse;
     uint8_t stick_deadzone;
-    uint8_t controller_touchpad_mode;
-    bool controller_touchpad_multitouch;
-    short controller_touchpad_count;
-    float controller_touchpad_mouse_gain;
-    float controller_touchpad_scroll_scale;
+    uint8_t touchpad_mode;
+    bool touchpad_multitouch;
+    short touchpad_count;
+    float touchpad_mouse_gain;
+    float touchpad_scroll_scale;
     session_input_vmouse_t vmouse;
-    session_input_controller_touchpad_t *controller_touchpads;
+    session_input_touchpad_t *touchpads;
 #if FEATURE_INPUT_EVMOUSE
     session_evmouse_t evmouse;
 #endif
@@ -59,9 +59,9 @@ void session_input_started(stream_input_t *input);
 
 void session_input_stopped(stream_input_t *input);
 
-void stream_input_controller_touchpad_mouse_init(stream_input_t *input);
+void stream_input_touchpad_mouse_init(stream_input_t *input);
 
-void stream_input_controller_touchpad_mouse_deinit(stream_input_t *input);
+void stream_input_touchpad_mouse_deinit(stream_input_t *input);
 
 void session_input_screen_keyboard_opened(stream_input_t *input);
 
@@ -83,7 +83,7 @@ void stream_input_handle_ctouchpad(stream_input_t *input, const SDL_ControllerTo
 
 void stream_input_handle_cdevice(stream_input_t *input, const SDL_ControllerDeviceEvent *event);
 
-void stream_input_update_controller_touchpad_tap_hold(stream_input_t *input);
+void stream_input_update_touchpad_tap_hold(stream_input_t *input);
 
 void stream_input_handle_mmotion(stream_input_t *input, const SDL_MouseMotionEvent *event, bool hw_mouse);
 

--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -248,6 +248,13 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
                          const CONFIGURATION *app_config) {
     config->stream = app_config->stream;
     config->vmouse = app_config->virtual_mouse;
+    config->controller_touchpad_mode = app_config->controller_touchpad_mode;
+    config->controller_touchpad_sensitivity = app_config->controller_touchpad_sensitivity;
+    config->controller_touchpad_press = app_config->controller_touchpad_press;
+    config->controller_touchpad_secondary_click = app_config->controller_touchpad_secondary_click;
+    config->controller_touchpad_tap_to_click = app_config->controller_touchpad_tap_to_click;
+    config->controller_touchpad_two_finger_scroll = app_config->controller_touchpad_two_finger_scroll;
+    config->controller_touchpad_invert_two_finger_scroll = app_config->controller_touchpad_invert_two_finger_scroll;
     config->hardware_mouse = app_config->hardware_mouse;
     config->local_audio = app_config->localaudio;
     config->view_only = app_config->viewonly;

--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -250,11 +250,8 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
     config->vmouse = app_config->virtual_mouse;
     config->controller_touchpad_mode = app_config->controller_touchpad_mode;
     config->controller_touchpad_sensitivity = app_config->controller_touchpad_sensitivity;
-    config->controller_touchpad_press = app_config->controller_touchpad_press;
-    config->controller_touchpad_secondary_click = app_config->controller_touchpad_secondary_click;
-    config->controller_touchpad_tap_to_click = app_config->controller_touchpad_tap_to_click;
-    config->controller_touchpad_two_finger_scroll = app_config->controller_touchpad_two_finger_scroll;
-    config->controller_touchpad_invert_two_finger_scroll = app_config->controller_touchpad_invert_two_finger_scroll;
+    config->controller_touchpad_multitouch = app_config->controller_touchpad_multitouch;
+    config->controller_touchpad_natural_scroll = app_config->controller_touchpad_natural_scroll;
     config->hardware_mouse = app_config->hardware_mouse;
     config->local_audio = app_config->localaudio;
     config->view_only = app_config->viewonly;

--- a/src/app/stream/session.c
+++ b/src/app/stream/session.c
@@ -248,10 +248,10 @@ void session_config_init(app_t *app, session_config_t *config, const SERVER_DATA
                          const CONFIGURATION *app_config) {
     config->stream = app_config->stream;
     config->vmouse = app_config->virtual_mouse;
-    config->controller_touchpad_mode = app_config->controller_touchpad_mode;
-    config->controller_touchpad_sensitivity = app_config->controller_touchpad_sensitivity;
-    config->controller_touchpad_multitouch = app_config->controller_touchpad_multitouch;
-    config->controller_touchpad_natural_scroll = app_config->controller_touchpad_natural_scroll;
+    config->touchpad_mode = app_config->touchpad_mode;
+    config->touchpad_speed = app_config->touchpad_speed;
+    config->touchpad_multitouch = app_config->touchpad_multitouch;
+    config->touchpad_natural_scroll = app_config->touchpad_natural_scroll;
     config->hardware_mouse = app_config->hardware_mouse;
     config->local_audio = app_config->localaudio;
     config->view_only = app_config->viewonly;

--- a/src/app/stream/session.h
+++ b/src/app/stream/session.h
@@ -60,10 +60,10 @@ typedef struct session_config_t {
     bool local_audio;
     bool hardware_mouse;
     bool vmouse;
-    int controller_touchpad_mode;
-    int controller_touchpad_sensitivity;
-    bool controller_touchpad_multitouch;
-    bool controller_touchpad_natural_scroll;
+    int touchpad_mode;
+    int touchpad_speed;
+    bool touchpad_multitouch;
+    bool touchpad_natural_scroll;
     uint8_t stick_deadzone;
 } session_config_t;
 

--- a/src/app/stream/session.h
+++ b/src/app/stream/session.h
@@ -62,11 +62,8 @@ typedef struct session_config_t {
     bool vmouse;
     int controller_touchpad_mode;
     int controller_touchpad_sensitivity;
-    int controller_touchpad_press;
-    int controller_touchpad_secondary_click;
-    bool controller_touchpad_tap_to_click;
-    bool controller_touchpad_two_finger_scroll;
-    bool controller_touchpad_invert_two_finger_scroll;
+    bool controller_touchpad_multitouch;
+    bool controller_touchpad_natural_scroll;
     uint8_t stick_deadzone;
 } session_config_t;
 

--- a/src/app/stream/session.h
+++ b/src/app/stream/session.h
@@ -60,6 +60,13 @@ typedef struct session_config_t {
     bool local_audio;
     bool hardware_mouse;
     bool vmouse;
+    int controller_touchpad_mode;
+    int controller_touchpad_sensitivity;
+    int controller_touchpad_press;
+    int controller_touchpad_secondary_click;
+    bool controller_touchpad_tap_to_click;
+    bool controller_touchpad_two_finger_scroll;
+    bool controller_touchpad_invert_two_finger_scroll;
     uint8_t stick_deadzone;
 } session_config_t;
 

--- a/src/app/stream/session_events.c
+++ b/src/app/stream/session_events.c
@@ -75,7 +75,7 @@ void session_update_controller_touchpad_tap_hold(session_t *session) {
     }
 
     stream_input_t *input = &session->input;
-    if (input->controller_touchpads != NULL && input->controller_touchpad_tap_to_click) {
+    if (input->controller_touchpads != NULL) {
         stream_input_update_controller_touchpad_tap_hold(input);
     }
 }

--- a/src/app/stream/session_events.c
+++ b/src/app/stream/session_events.c
@@ -68,3 +68,14 @@ bool session_handle_input_event(session_t *session, const SDL_Event *event) {
     }
     return true;
 }
+
+void session_update_controller_touchpad_tap_hold(session_t *session) {
+    if (!session_accepting_input(session)) {
+        return;
+    }
+
+    stream_input_t *input = &session->input;
+    if (input->controller_touchpads != NULL && input->controller_touchpad_tap_to_click) {
+        stream_input_update_controller_touchpad_tap_hold(input);
+    }
+}

--- a/src/app/stream/session_events.c
+++ b/src/app/stream/session_events.c
@@ -69,13 +69,13 @@ bool session_handle_input_event(session_t *session, const SDL_Event *event) {
     return true;
 }
 
-void session_update_controller_touchpad_tap_hold(session_t *session) {
+void session_update_touchpad_tap_hold(session_t *session) {
     if (!session_accepting_input(session)) {
         return;
     }
 
     stream_input_t *input = &session->input;
-    if (input->controller_touchpads != NULL) {
-        stream_input_update_controller_touchpad_tap_hold(input);
+    if (input->touchpads != NULL) {
+        stream_input_update_touchpad_tap_hold(input);
     }
 }

--- a/src/app/stream/session_events.h
+++ b/src/app/stream/session_events.h
@@ -6,3 +6,5 @@
 typedef struct session_t session_t;
 
 bool session_handle_input_event(session_t *session, const SDL_Event *event);
+
+void session_update_controller_touchpad_tap_hold(session_t *session);

--- a/src/app/stream/session_events.h
+++ b/src/app/stream/session_events.h
@@ -7,4 +7,4 @@ typedef struct session_t session_t;
 
 bool session_handle_input_event(session_t *session, const SDL_Event *event);
 
-void session_update_controller_touchpad_tap_hold(session_t *session);
+void session_update_touchpad_tap_hold(session_t *session);

--- a/src/app/ui/settings/panes/input.pane.c
+++ b/src/app/ui/settings/panes/input.pane.c
@@ -11,11 +11,25 @@ typedef struct input_pane_t {
     lv_obj_t *absmouse_toggle;
     lv_obj_t *absmouse_hint;
     lv_obj_t *deadzone_label;
+
+    pref_dropdown_int_entry_t controller_touchpad_mode_entries[3];
+    pref_dropdown_int_entry_t controller_touchpad_press_entries[4];
+
+    lv_obj_t *controller_touchpad_sensitivity_label;
+    lv_obj_t *controller_touchpad_mouse_controls[6];
 } input_pane_t;
 
 static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *view);
 
 static void pane_ctor(lv_fragment_t *self, void *args);
+
+static void on_controller_touchpad_mode_changed(lv_event_t *e);
+
+static void on_controller_touchpad_sensitivity_changed(lv_event_t *e);
+
+static void update_controller_touchpad_mouse_options(input_pane_t *pane);
+
+static void update_controller_touchpad_sensitivity_label(input_pane_t *pane);
 
 #if FEATURE_INPUT_EVMOUSE
 static void hwmouse_state_update_cb(lv_event_t *e);
@@ -43,6 +57,22 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_set_layout(view, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(view, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(view, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    pane->controller_touchpad_mode_entries[0] = (pref_dropdown_int_entry_t) {
+            locstr("Disabled"), CONTROLLER_TOUCHPAD_MODE_DISABLED, false};
+    pane->controller_touchpad_mode_entries[1] = (pref_dropdown_int_entry_t) {
+            locstr("Mouse"), CONTROLLER_TOUCHPAD_MODE_MOUSE, true};
+    pane->controller_touchpad_mode_entries[2] = (pref_dropdown_int_entry_t) {
+            locstr("Native"), CONTROLLER_TOUCHPAD_MODE_NATIVE, false};
+
+    pane->controller_touchpad_press_entries[0] = (pref_dropdown_int_entry_t) {
+            locstr("Off"), CONTROLLER_TOUCHPAD_PRESS_DISABLED, false};
+    pane->controller_touchpad_press_entries[1] = (pref_dropdown_int_entry_t) {
+            locstr("Left click"), CONTROLLER_TOUCHPAD_PRESS_LEFT, true};
+    pane->controller_touchpad_press_entries[2] = (pref_dropdown_int_entry_t) {
+            locstr("Right click"), CONTROLLER_TOUCHPAD_PRESS_RIGHT, false};
+    pane->controller_touchpad_press_entries[3] = (pref_dropdown_int_entry_t) {
+            locstr("Middle click"), CONTROLLER_TOUCHPAD_PRESS_MIDDLE, false};
+
     pref_checkbox(view, locstr("View-only mode"), &app_configuration->viewonly, false);
     pref_desc_label(view, locstr("Don't send mouse, keyboard or gamepad input to host computer."), false);
 
@@ -82,11 +112,110 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     pref_desc_label(view, locstr("Swap A/B and X/Y gamepad buttons. Useful when you prefer Nintendo-like layouts."),
                     false);
 
+    pref_header(view, locstr("Controller touchpad"));
+
+    pref_title_label(view, locstr("Mode"));
+    lv_obj_t *mode_dropdown = pref_dropdown_int(view,
+                                                pane->controller_touchpad_mode_entries,
+                                                sizeof(pane->controller_touchpad_mode_entries) /
+                                                        sizeof(*pane->controller_touchpad_mode_entries),
+                                                &app_configuration->controller_touchpad_mode,
+                                                NULL);
+    lv_obj_set_width(mode_dropdown, LV_PCT(100));
+    lv_obj_add_event_cb(mode_dropdown, on_controller_touchpad_mode_changed, LV_EVENT_VALUE_CHANGED, pane);
+    pref_desc_label(view, locstr("Disabled ignores controller touchpad input. Mouse uses it as a relative "
+                                 "trackpad. Native forwards controller touch events and the touchpad button "
+                                 "to the host."), false);
+
+    size_t mouse_control = 0;
+    pane->controller_touchpad_sensitivity_label = pref_title_label(view, NULL);
+    lv_obj_t *sensitivity_slider =
+            pane->controller_touchpad_mouse_controls[mouse_control++] =
+                    pref_slider(view, &app_configuration->controller_touchpad_sensitivity,
+                                CONTROLLER_TOUCHPAD_SENSITIVITY_MIN,
+                                CONTROLLER_TOUCHPAD_SENSITIVITY_MAX, 5);
+    lv_obj_set_width(sensitivity_slider, LV_PCT(100));
+    lv_obj_add_event_cb(sensitivity_slider, on_controller_touchpad_sensitivity_changed,
+                        LV_EVENT_VALUE_CHANGED, pane);
+    pref_desc_label(view, locstr("Adjust relative pointer speed in Mouse mode."), false);
+
+    pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_checkbox(view, locstr("Tap to click"),
+                          &app_configuration->controller_touchpad_tap_to_click, false);
+    pref_desc_label(view, locstr("Tap once with one finger to send a left click. "
+                                 "Touch and hold briefly to hold left click for dragging."), false);
+
+    pref_title_label(view, locstr("Physical press"));
+    lv_obj_t *press_dropdown = pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_dropdown_int(view,
+                              pane->controller_touchpad_press_entries,
+                              sizeof(pane->controller_touchpad_press_entries) /
+                                      sizeof(*pane->controller_touchpad_press_entries),
+                              &app_configuration->controller_touchpad_press,
+                              NULL);
+    lv_obj_set_width(press_dropdown, LV_PCT(100));
+    pref_desc_label(view, locstr("Choose the mouse button sent for a normal physical touchpad press."),
+                    false);
+
+    pref_title_label(view, locstr("Secondary click"));
+    lv_obj_t *secondary_click_dropdown = pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_dropdown_int(view,
+                              pane->controller_touchpad_press_entries,
+                              sizeof(pane->controller_touchpad_press_entries) /
+                                      sizeof(*pane->controller_touchpad_press_entries),
+                              &app_configuration->controller_touchpad_secondary_click,
+                              NULL);
+    lv_obj_set_width(secondary_click_dropdown, LV_PCT(100));
+    pref_desc_label(view, locstr("Used for a physical press in the lower-right corner or a two-finger tap."),
+                    false);
+
+    pane->controller_touchpad_mouse_controls[mouse_control++] =
+            pref_checkbox(view, locstr("Two-finger scrolling"),
+                          &app_configuration->controller_touchpad_two_finger_scroll, false);
+    pref_desc_label(view, locstr("Scroll vertically or horizontally by moving two fingers together."),
+                    false);
+
+    pane->controller_touchpad_mouse_controls[mouse_control] =
+            pref_checkbox(view, locstr("Invert two-finger scrolling"),
+                          &app_configuration->controller_touchpad_invert_two_finger_scroll, false);
+    pref_desc_label(view, locstr("Use natural scrolling so content follows your fingers, like on macOS."),
+                    false);
+
+    update_controller_touchpad_sensitivity_label(pane);
+    update_controller_touchpad_mouse_options(pane);
+
 #if FEATURE_INPUT_EVMOUSE
     hwmouse_state_update(pane);
 #endif
     update_deadzone_label(pane);
     return view;
+}
+
+static void on_controller_touchpad_mode_changed(lv_event_t *e) {
+    input_pane_t *pane = lv_event_get_user_data(e);
+    update_controller_touchpad_mouse_options(pane);
+}
+
+static void on_controller_touchpad_sensitivity_changed(lv_event_t *e) {
+    input_pane_t *pane = lv_event_get_user_data(e);
+    update_controller_touchpad_sensitivity_label(pane);
+}
+
+static void update_controller_touchpad_mouse_options(input_pane_t *pane) {
+    bool mouse_mode = app_configuration->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_MOUSE;
+    for (size_t i = 0; i < sizeof(pane->controller_touchpad_mouse_controls) /
+                           sizeof(*pane->controller_touchpad_mouse_controls); ++i) {
+        if (mouse_mode) {
+            lv_obj_clear_state(pane->controller_touchpad_mouse_controls[i], LV_STATE_DISABLED);
+        } else {
+            lv_obj_add_state(pane->controller_touchpad_mouse_controls[i], LV_STATE_DISABLED);
+        }
+    }
+}
+
+static void update_controller_touchpad_sensitivity_label(input_pane_t *pane) {
+    lv_label_set_text_fmt(pane->controller_touchpad_sensitivity_label, "%s - %d%%",
+                          locstr("Sensitivity"), app_configuration->controller_touchpad_sensitivity);
 }
 
 #if FEATURE_INPUT_EVMOUSE

--- a/src/app/ui/settings/panes/input.pane.c
+++ b/src/app/ui/settings/panes/input.pane.c
@@ -12,22 +12,15 @@ typedef struct input_pane_t {
     lv_obj_t *absmouse_hint;
     lv_obj_t *deadzone_label;
 
-    pref_dropdown_int_entry_t controller_touchpad_mode_entries[3];
-    pref_dropdown_int_entry_t controller_touchpad_press_entries[4];
-
+    pref_dropdown_int_entry_t controller_touchpad_mode_entries[2];
     lv_obj_t *controller_touchpad_sensitivity_label;
-    lv_obj_t *controller_touchpad_mouse_controls[6];
 } input_pane_t;
 
 static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *view);
 
 static void pane_ctor(lv_fragment_t *self, void *args);
 
-static void on_controller_touchpad_mode_changed(lv_event_t *e);
-
 static void on_controller_touchpad_sensitivity_changed(lv_event_t *e);
-
-static void update_controller_touchpad_mouse_options(input_pane_t *pane);
 
 static void update_controller_touchpad_sensitivity_label(input_pane_t *pane);
 
@@ -58,20 +51,9 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_set_flex_flow(view, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(view, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     pane->controller_touchpad_mode_entries[0] = (pref_dropdown_int_entry_t) {
-            locstr("Disabled"), CONTROLLER_TOUCHPAD_MODE_DISABLED, false};
+            locstr("Send as mouse"), CONTROLLER_TOUCHPAD_MODE_MOUSE, false};
     pane->controller_touchpad_mode_entries[1] = (pref_dropdown_int_entry_t) {
-            locstr("Mouse"), CONTROLLER_TOUCHPAD_MODE_MOUSE, true};
-    pane->controller_touchpad_mode_entries[2] = (pref_dropdown_int_entry_t) {
-            locstr("Native"), CONTROLLER_TOUCHPAD_MODE_NATIVE, false};
-
-    pane->controller_touchpad_press_entries[0] = (pref_dropdown_int_entry_t) {
-            locstr("Off"), CONTROLLER_TOUCHPAD_PRESS_DISABLED, false};
-    pane->controller_touchpad_press_entries[1] = (pref_dropdown_int_entry_t) {
-            locstr("Left click"), CONTROLLER_TOUCHPAD_PRESS_LEFT, true};
-    pane->controller_touchpad_press_entries[2] = (pref_dropdown_int_entry_t) {
-            locstr("Right click"), CONTROLLER_TOUCHPAD_PRESS_RIGHT, false};
-    pane->controller_touchpad_press_entries[3] = (pref_dropdown_int_entry_t) {
-            locstr("Middle click"), CONTROLLER_TOUCHPAD_PRESS_MIDDLE, false};
+            locstr("Send as touchpad"), CONTROLLER_TOUCHPAD_MODE_NATIVE, true};
 
     pref_checkbox(view, locstr("View-only mode"), &app_configuration->viewonly, false);
     pref_desc_label(view, locstr("Don't send mouse, keyboard or gamepad input to host computer."), false);
@@ -115,74 +97,34 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     pref_header(view, locstr("Controller touchpad"));
 
     pref_title_label(view, locstr("Mode"));
-    lv_obj_t *mode_dropdown = pref_dropdown_int(view,
-                                                pane->controller_touchpad_mode_entries,
+    lv_obj_t *mode_dropdown = pref_dropdown_int(view, pane->controller_touchpad_mode_entries,
                                                 sizeof(pane->controller_touchpad_mode_entries) /
                                                         sizeof(*pane->controller_touchpad_mode_entries),
-                                                &app_configuration->controller_touchpad_mode,
-                                                NULL);
+                                                &app_configuration->controller_touchpad_mode, NULL);
     lv_obj_set_width(mode_dropdown, LV_PCT(100));
-    lv_obj_add_event_cb(mode_dropdown, on_controller_touchpad_mode_changed, LV_EVENT_VALUE_CHANGED, pane);
-    pref_desc_label(view, locstr("Disabled ignores controller touchpad input. Mouse uses it as a relative "
-                                 "trackpad. Native forwards controller touch events and the touchpad button "
-                                 "to the host."), false);
+    pref_desc_label(view, locstr("Send as mouse uses the touchpad as a trackpad. "
+                                 "Send as touchpad forwards touches to the host, for games "
+                                 "with built-in touchpad support."), false);
 
-    size_t mouse_control = 0;
     pane->controller_touchpad_sensitivity_label = pref_title_label(view, NULL);
-    lv_obj_t *sensitivity_slider =
-            pane->controller_touchpad_mouse_controls[mouse_control++] =
-                    pref_slider(view, &app_configuration->controller_touchpad_sensitivity,
-                                CONTROLLER_TOUCHPAD_SENSITIVITY_MIN,
-                                CONTROLLER_TOUCHPAD_SENSITIVITY_MAX, 5);
+    lv_obj_t *sensitivity_slider = pref_slider(view, &app_configuration->controller_touchpad_sensitivity,
+                                               CONTROLLER_TOUCHPAD_SENSITIVITY_MIN,
+                                               CONTROLLER_TOUCHPAD_SENSITIVITY_MAX, 5);
     lv_obj_set_width(sensitivity_slider, LV_PCT(100));
     lv_obj_add_event_cb(sensitivity_slider, on_controller_touchpad_sensitivity_changed,
                         LV_EVENT_VALUE_CHANGED, pane);
-    pref_desc_label(view, locstr("Adjust relative pointer speed in Mouse mode."), false);
+    pref_desc_label(view, locstr("Adjust pointer speed when the touchpad is used as a mouse."), false);
 
-    pane->controller_touchpad_mouse_controls[mouse_control++] =
-            pref_checkbox(view, locstr("Tap to click"),
-                          &app_configuration->controller_touchpad_tap_to_click, false);
-    pref_desc_label(view, locstr("Tap once with one finger to send a left click. "
-                                 "Touch and hold briefly to hold left click for dragging."), false);
+    pref_checkbox(view, locstr("Multi-touch gestures"),
+                  &app_configuration->controller_touchpad_multitouch, false);
+    pref_desc_label(view, locstr("Use two fingers to scroll and to right click. "
+                                 "Turn off if you trigger them by accident."), false);
 
-    pref_title_label(view, locstr("Physical press"));
-    lv_obj_t *press_dropdown = pane->controller_touchpad_mouse_controls[mouse_control++] =
-            pref_dropdown_int(view,
-                              pane->controller_touchpad_press_entries,
-                              sizeof(pane->controller_touchpad_press_entries) /
-                                      sizeof(*pane->controller_touchpad_press_entries),
-                              &app_configuration->controller_touchpad_press,
-                              NULL);
-    lv_obj_set_width(press_dropdown, LV_PCT(100));
-    pref_desc_label(view, locstr("Choose the mouse button sent for a normal physical touchpad press."),
-                    false);
-
-    pref_title_label(view, locstr("Secondary click"));
-    lv_obj_t *secondary_click_dropdown = pane->controller_touchpad_mouse_controls[mouse_control++] =
-            pref_dropdown_int(view,
-                              pane->controller_touchpad_press_entries,
-                              sizeof(pane->controller_touchpad_press_entries) /
-                                      sizeof(*pane->controller_touchpad_press_entries),
-                              &app_configuration->controller_touchpad_secondary_click,
-                              NULL);
-    lv_obj_set_width(secondary_click_dropdown, LV_PCT(100));
-    pref_desc_label(view, locstr("Used for a physical press in the lower-right corner or a two-finger tap."),
-                    false);
-
-    pane->controller_touchpad_mouse_controls[mouse_control++] =
-            pref_checkbox(view, locstr("Two-finger scrolling"),
-                          &app_configuration->controller_touchpad_two_finger_scroll, false);
-    pref_desc_label(view, locstr("Scroll vertically or horizontally by moving two fingers together."),
-                    false);
-
-    pane->controller_touchpad_mouse_controls[mouse_control] =
-            pref_checkbox(view, locstr("Invert two-finger scrolling"),
-                          &app_configuration->controller_touchpad_invert_two_finger_scroll, false);
-    pref_desc_label(view, locstr("Use natural scrolling so content follows your fingers, like on macOS."),
-                    false);
+    pref_checkbox(view, locstr("Natural scrolling"),
+                  &app_configuration->controller_touchpad_natural_scroll, false);
+    pref_desc_label(view, locstr("Scrolling follows your fingers, like on a phone."), false);
 
     update_controller_touchpad_sensitivity_label(pane);
-    update_controller_touchpad_mouse_options(pane);
 
 #if FEATURE_INPUT_EVMOUSE
     hwmouse_state_update(pane);
@@ -191,31 +133,14 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     return view;
 }
 
-static void on_controller_touchpad_mode_changed(lv_event_t *e) {
-    input_pane_t *pane = lv_event_get_user_data(e);
-    update_controller_touchpad_mouse_options(pane);
-}
-
 static void on_controller_touchpad_sensitivity_changed(lv_event_t *e) {
     input_pane_t *pane = lv_event_get_user_data(e);
     update_controller_touchpad_sensitivity_label(pane);
 }
 
-static void update_controller_touchpad_mouse_options(input_pane_t *pane) {
-    bool mouse_mode = app_configuration->controller_touchpad_mode == CONTROLLER_TOUCHPAD_MODE_MOUSE;
-    for (size_t i = 0; i < sizeof(pane->controller_touchpad_mouse_controls) /
-                           sizeof(*pane->controller_touchpad_mouse_controls); ++i) {
-        if (mouse_mode) {
-            lv_obj_clear_state(pane->controller_touchpad_mouse_controls[i], LV_STATE_DISABLED);
-        } else {
-            lv_obj_add_state(pane->controller_touchpad_mouse_controls[i], LV_STATE_DISABLED);
-        }
-    }
-}
-
 static void update_controller_touchpad_sensitivity_label(input_pane_t *pane) {
     lv_label_set_text_fmt(pane->controller_touchpad_sensitivity_label, "%s - %d%%",
-                          locstr("Sensitivity"), app_configuration->controller_touchpad_sensitivity);
+                          locstr("Pointer speed"), app_configuration->controller_touchpad_sensitivity);
 }
 
 #if FEATURE_INPUT_EVMOUSE

--- a/src/app/ui/settings/panes/input.pane.c
+++ b/src/app/ui/settings/panes/input.pane.c
@@ -12,17 +12,17 @@ typedef struct input_pane_t {
     lv_obj_t *absmouse_hint;
     lv_obj_t *deadzone_label;
 
-    pref_dropdown_int_entry_t controller_touchpad_mode_entries[2];
-    lv_obj_t *controller_touchpad_sensitivity_label;
+    pref_dropdown_int_entry_t touchpad_mode_entries[2];
+    lv_obj_t *touchpad_speed_label;
 } input_pane_t;
 
 static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *view);
 
 static void pane_ctor(lv_fragment_t *self, void *args);
 
-static void on_controller_touchpad_sensitivity_changed(lv_event_t *e);
+static void on_touchpad_speed_changed(lv_event_t *e);
 
-static void update_controller_touchpad_sensitivity_label(input_pane_t *pane);
+static void update_touchpad_speed_label(input_pane_t *pane);
 
 #if FEATURE_INPUT_EVMOUSE
 static void hwmouse_state_update_cb(lv_event_t *e);
@@ -50,10 +50,10 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_set_layout(view, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(view, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(view, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-    pane->controller_touchpad_mode_entries[0] = (pref_dropdown_int_entry_t) {
-            locstr("Send as mouse"), CONTROLLER_TOUCHPAD_MODE_MOUSE, false};
-    pane->controller_touchpad_mode_entries[1] = (pref_dropdown_int_entry_t) {
-            locstr("Send as touchpad"), CONTROLLER_TOUCHPAD_MODE_NATIVE, true};
+    pane->touchpad_mode_entries[0] = (pref_dropdown_int_entry_t) {
+            locstr("Send as mouse"), TOUCHPAD_MODE_MOUSE, false};
+    pane->touchpad_mode_entries[1] = (pref_dropdown_int_entry_t) {
+            locstr("Send as touchpad"), TOUCHPAD_MODE_NATIVE, true};
 
     pref_checkbox(view, locstr("View-only mode"), &app_configuration->viewonly, false);
     pref_desc_label(view, locstr("Don't send mouse, keyboard or gamepad input to host computer."), false);
@@ -97,34 +97,34 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     pref_header(view, locstr("Controller touchpad"));
 
     pref_title_label(view, locstr("Mode"));
-    lv_obj_t *mode_dropdown = pref_dropdown_int(view, pane->controller_touchpad_mode_entries,
-                                                sizeof(pane->controller_touchpad_mode_entries) /
-                                                        sizeof(*pane->controller_touchpad_mode_entries),
-                                                &app_configuration->controller_touchpad_mode, NULL);
+    lv_obj_t *mode_dropdown = pref_dropdown_int(view, pane->touchpad_mode_entries,
+                                                sizeof(pane->touchpad_mode_entries) /
+                                                        sizeof(*pane->touchpad_mode_entries),
+                                                &app_configuration->touchpad_mode, NULL);
     lv_obj_set_width(mode_dropdown, LV_PCT(100));
     pref_desc_label(view, locstr("Send as mouse uses the touchpad as a trackpad. "
                                  "Send as touchpad forwards touches to the host, for games "
                                  "with built-in touchpad support."), false);
 
-    pane->controller_touchpad_sensitivity_label = pref_title_label(view, NULL);
-    lv_obj_t *sensitivity_slider = pref_slider(view, &app_configuration->controller_touchpad_sensitivity,
-                                               CONTROLLER_TOUCHPAD_SENSITIVITY_MIN,
-                                               CONTROLLER_TOUCHPAD_SENSITIVITY_MAX, 5);
+    pane->touchpad_speed_label = pref_title_label(view, NULL);
+    lv_obj_t *sensitivity_slider = pref_slider(view, &app_configuration->touchpad_speed,
+                                               TOUCHPAD_SPEED_MIN,
+                                               TOUCHPAD_SPEED_MAX, 5);
     lv_obj_set_width(sensitivity_slider, LV_PCT(100));
-    lv_obj_add_event_cb(sensitivity_slider, on_controller_touchpad_sensitivity_changed,
+    lv_obj_add_event_cb(sensitivity_slider, on_touchpad_speed_changed,
                         LV_EVENT_VALUE_CHANGED, pane);
     pref_desc_label(view, locstr("Adjust pointer speed when the touchpad is used as a mouse."), false);
 
     pref_checkbox(view, locstr("Multi-touch gestures"),
-                  &app_configuration->controller_touchpad_multitouch, false);
+                  &app_configuration->touchpad_multitouch, false);
     pref_desc_label(view, locstr("Use two fingers to scroll and to right click. "
                                  "Turn off if you trigger them by accident."), false);
 
     pref_checkbox(view, locstr("Natural scrolling"),
-                  &app_configuration->controller_touchpad_natural_scroll, false);
+                  &app_configuration->touchpad_natural_scroll, false);
     pref_desc_label(view, locstr("Scrolling follows your fingers, like on a phone."), false);
 
-    update_controller_touchpad_sensitivity_label(pane);
+    update_touchpad_speed_label(pane);
 
 #if FEATURE_INPUT_EVMOUSE
     hwmouse_state_update(pane);
@@ -133,14 +133,14 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     return view;
 }
 
-static void on_controller_touchpad_sensitivity_changed(lv_event_t *e) {
+static void on_touchpad_speed_changed(lv_event_t *e) {
     input_pane_t *pane = lv_event_get_user_data(e);
-    update_controller_touchpad_sensitivity_label(pane);
+    update_touchpad_speed_label(pane);
 }
 
-static void update_controller_touchpad_sensitivity_label(input_pane_t *pane) {
-    lv_label_set_text_fmt(pane->controller_touchpad_sensitivity_label, "%s - %d%%",
-                          locstr("Pointer speed"), app_configuration->controller_touchpad_sensitivity);
+static void update_touchpad_speed_label(input_pane_t *pane) {
+    lv_label_set_text_fmt(pane->touchpad_speed_label, "%s - %d%%",
+                          locstr("Pointer speed"), app_configuration->touchpad_speed);
 }
 
 #if FEATURE_INPUT_EVMOUSE

--- a/src/app/ui/settings/panes/input.pane.c
+++ b/src/app/ui/settings/panes/input.pane.c
@@ -51,9 +51,9 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     lv_obj_set_flex_flow(view, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(view, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
     pane->touchpad_mode_entries[0] = (pref_dropdown_int_entry_t) {
-            locstr("Send as mouse"), TOUCHPAD_MODE_MOUSE, false};
-    pane->touchpad_mode_entries[1] = (pref_dropdown_int_entry_t) {
             locstr("Send as touchpad"), TOUCHPAD_MODE_NATIVE, true};
+    pane->touchpad_mode_entries[1] = (pref_dropdown_int_entry_t) {
+            locstr("Send as mouse"), TOUCHPAD_MODE_MOUSE, false};
 
     pref_checkbox(view, locstr("View-only mode"), &app_configuration->viewonly, false);
     pref_desc_label(view, locstr("Don't send mouse, keyboard or gamepad input to host computer."), false);
@@ -94,7 +94,7 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     pref_desc_label(view, locstr("Swap A/B and X/Y gamepad buttons. Useful when you prefer Nintendo-like layouts."),
                     false);
 
-    pref_header(view, locstr("Controller touchpad"));
+    pref_header(view, locstr("Gamepad touchpad"));
 
     pref_title_label(view, locstr("Mode"));
     lv_obj_t *mode_dropdown = pref_dropdown_int(view, pane->touchpad_mode_entries,
@@ -102,9 +102,9 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
                                                         sizeof(*pane->touchpad_mode_entries),
                                                 &app_configuration->touchpad_mode, NULL);
     lv_obj_set_width(mode_dropdown, LV_PCT(100));
-    pref_desc_label(view, locstr("Send as mouse uses the touchpad as a trackpad. "
-                                 "Send as touchpad forwards touches to the host, for games "
-                                 "with built-in touchpad support."), false);
+    pref_desc_label(view, locstr("Send as touchpad forwards touches to the host, for games "
+                                 "with built-in touchpad support. Send as mouse uses the "
+                                 "touchpad as a trackpad instead."), false);
 
     pane->touchpad_speed_label = pref_title_label(view, NULL);
     lv_obj_t *sensitivity_slider = pref_slider(view, &app_configuration->touchpad_speed,

--- a/tests/app/test_settings.c
+++ b/tests/app/test_settings.c
@@ -30,21 +30,15 @@ void testReadINI() {
     settings.ini_path = ini_backup;
     TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, settings.controller_touchpad_mode);
     TEST_ASSERT_EQUAL_INT(125, settings.controller_touchpad_sensitivity);
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_RIGHT, settings.controller_touchpad_press);
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_MIDDLE, settings.controller_touchpad_secondary_click);
-    TEST_ASSERT_FALSE(settings.controller_touchpad_tap_to_click);
-    TEST_ASSERT_TRUE(settings.controller_touchpad_two_finger_scroll);
-    TEST_ASSERT_FALSE(settings.controller_touchpad_invert_two_finger_scroll);
+    TEST_ASSERT_FALSE(settings.controller_touchpad_multitouch);
+    TEST_ASSERT_FALSE(settings.controller_touchpad_natural_scroll);
 }
 
 void testWriteINI() {
-    settings.controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_NATIVE;
+    settings.controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_MOUSE;
     settings.controller_touchpad_sensitivity = 175;
-    settings.controller_touchpad_press = CONTROLLER_TOUCHPAD_PRESS_MIDDLE;
-    settings.controller_touchpad_secondary_click = CONTROLLER_TOUCHPAD_PRESS_LEFT;
-    settings.controller_touchpad_tap_to_click = false;
-    settings.controller_touchpad_two_finger_scroll = true;
-    settings.controller_touchpad_invert_two_finger_scroll = false;
+    settings.controller_touchpad_multitouch = false;
+    settings.controller_touchpad_natural_scroll = false;
 
     char *ini_backup = settings.ini_path;
     settings.ini_path = "settings_write_tmp.ini";
@@ -58,26 +52,42 @@ void testWriteINI() {
     TEST_ASSERT_TRUE(settings_read(&loaded));
     loaded.ini_path = loaded_ini_backup;
 
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_NATIVE, loaded.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, loaded.controller_touchpad_mode);
     TEST_ASSERT_EQUAL_INT(175, loaded.controller_touchpad_sensitivity);
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_MIDDLE, loaded.controller_touchpad_press);
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_LEFT, loaded.controller_touchpad_secondary_click);
-    TEST_ASSERT_FALSE(loaded.controller_touchpad_tap_to_click);
-    TEST_ASSERT_TRUE(loaded.controller_touchpad_two_finger_scroll);
-    TEST_ASSERT_FALSE(loaded.controller_touchpad_invert_two_finger_scroll);
+    TEST_ASSERT_FALSE(loaded.controller_touchpad_multitouch);
+    TEST_ASSERT_FALSE(loaded.controller_touchpad_natural_scroll);
 
     settings_clear(&loaded);
     remove("settings_write_tmp.ini");
 }
 
 void testControllerTouchpadDefaults() {
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, settings.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_NATIVE, settings.controller_touchpad_mode);
     TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT, settings.controller_touchpad_sensitivity);
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_LEFT, settings.controller_touchpad_press);
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_RIGHT, settings.controller_touchpad_secondary_click);
-    TEST_ASSERT_TRUE(settings.controller_touchpad_tap_to_click);
-    TEST_ASSERT_TRUE(settings.controller_touchpad_two_finger_scroll);
-    TEST_ASSERT_TRUE(settings.controller_touchpad_invert_two_finger_scroll);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_multitouch);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_natural_scroll);
+}
+
+void testControllerTouchpadLegacyOffMode() {
+    // "off" was a third mode in early revisions of this feature. It never shipped,
+    // but branch testers have it in their config, so it must land somewhere sane.
+    FILE *fp = fopen("settings_legacy_tmp.ini", "w");
+    TEST_ASSERT_NOT_NULL(fp);
+    fputs("[input]\ncontroller_touchpad = off\n", fp);
+    fclose(fp);
+
+    app_settings_t legacy;
+    settings_initialize(&legacy, settings.conf_dir);
+    legacy.controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_MOUSE;
+    char *legacy_ini_backup = legacy.ini_path;
+    legacy.ini_path = "settings_legacy_tmp.ini";
+    TEST_ASSERT_TRUE(settings_read(&legacy));
+    legacy.ini_path = legacy_ini_backup;
+
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_NATIVE, legacy.controller_touchpad_mode);
+
+    settings_clear(&legacy);
+    remove("settings_legacy_tmp.ini");
 }
 
 int main() {
@@ -85,5 +95,6 @@ int main() {
     RUN_TEST(testReadINI);
     RUN_TEST(testWriteINI);
     RUN_TEST(testControllerTouchpadDefaults);
+    RUN_TEST(testControllerTouchpadLegacyOffMode);
     return UNITY_END();
 }

--- a/tests/app/test_settings.c
+++ b/tests/app/test_settings.c
@@ -28,17 +28,17 @@ void testReadINI() {
     settings.ini_path = FIXTURES_PATH_PREFIX "settings_read.ini";
     TEST_ASSERT_TRUE(settings_read(&settings));
     settings.ini_path = ini_backup;
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, settings.controller_touchpad_mode);
-    TEST_ASSERT_EQUAL_INT(125, settings.controller_touchpad_sensitivity);
-    TEST_ASSERT_FALSE(settings.controller_touchpad_multitouch);
-    TEST_ASSERT_FALSE(settings.controller_touchpad_natural_scroll);
+    TEST_ASSERT_EQUAL_INT(TOUCHPAD_MODE_MOUSE, settings.touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(125, settings.touchpad_speed);
+    TEST_ASSERT_FALSE(settings.touchpad_multitouch);
+    TEST_ASSERT_FALSE(settings.touchpad_natural_scroll);
 }
 
 void testWriteINI() {
-    settings.controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_MOUSE;
-    settings.controller_touchpad_sensitivity = 175;
-    settings.controller_touchpad_multitouch = false;
-    settings.controller_touchpad_natural_scroll = false;
+    settings.touchpad_mode = TOUCHPAD_MODE_MOUSE;
+    settings.touchpad_speed = 175;
+    settings.touchpad_multitouch = false;
+    settings.touchpad_natural_scroll = false;
 
     char *ini_backup = settings.ini_path;
     settings.ini_path = "settings_write_tmp.ini";
@@ -52,42 +52,43 @@ void testWriteINI() {
     TEST_ASSERT_TRUE(settings_read(&loaded));
     loaded.ini_path = loaded_ini_backup;
 
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, loaded.controller_touchpad_mode);
-    TEST_ASSERT_EQUAL_INT(175, loaded.controller_touchpad_sensitivity);
-    TEST_ASSERT_FALSE(loaded.controller_touchpad_multitouch);
-    TEST_ASSERT_FALSE(loaded.controller_touchpad_natural_scroll);
+    TEST_ASSERT_EQUAL_INT(TOUCHPAD_MODE_MOUSE, loaded.touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(175, loaded.touchpad_speed);
+    TEST_ASSERT_FALSE(loaded.touchpad_multitouch);
+    TEST_ASSERT_FALSE(loaded.touchpad_natural_scroll);
 
     settings_clear(&loaded);
     remove("settings_write_tmp.ini");
 }
 
 void testControllerTouchpadDefaults() {
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_NATIVE, settings.controller_touchpad_mode);
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT, settings.controller_touchpad_sensitivity);
-    TEST_ASSERT_TRUE(settings.controller_touchpad_multitouch);
-    TEST_ASSERT_TRUE(settings.controller_touchpad_natural_scroll);
+    TEST_ASSERT_EQUAL_INT(TOUCHPAD_MODE_NATIVE, settings.touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(TOUCHPAD_SPEED_DEFAULT, settings.touchpad_speed);
+    TEST_ASSERT_TRUE(settings.touchpad_multitouch);
+    TEST_ASSERT_TRUE(settings.touchpad_natural_scroll);
 }
 
-void testControllerTouchpadLegacyOffMode() {
-    // "off" was a third mode in early revisions of this feature. It never shipped,
-    // but branch testers have it in their config, so it must land somewhere sane.
-    FILE *fp = fopen("settings_legacy_tmp.ini", "w");
+void testControllerTouchpadUnknownMode() {
+    // Anything we don't recognise -- including "off", a third mode that early
+    // revisions of this feature had and that never shipped -- has to land on the
+    // default rather than on whatever happened to be in the struct.
+    FILE *fp = fopen("settings_unknown_tmp.ini", "w");
     TEST_ASSERT_NOT_NULL(fp);
-    fputs("[input]\ncontroller_touchpad = off\n", fp);
+    fputs("[input]\ntouchpad_mode = off\n", fp);
     fclose(fp);
 
-    app_settings_t legacy;
-    settings_initialize(&legacy, settings.conf_dir);
-    legacy.controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_MOUSE;
-    char *legacy_ini_backup = legacy.ini_path;
-    legacy.ini_path = "settings_legacy_tmp.ini";
-    TEST_ASSERT_TRUE(settings_read(&legacy));
-    legacy.ini_path = legacy_ini_backup;
+    app_settings_t unknown;
+    settings_initialize(&unknown, settings.conf_dir);
+    unknown.touchpad_mode = TOUCHPAD_MODE_MOUSE;
+    char *unknown_ini_backup = unknown.ini_path;
+    unknown.ini_path = "settings_unknown_tmp.ini";
+    TEST_ASSERT_TRUE(settings_read(&unknown));
+    unknown.ini_path = unknown_ini_backup;
 
-    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_NATIVE, legacy.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(TOUCHPAD_MODE_NATIVE, unknown.touchpad_mode);
 
-    settings_clear(&legacy);
-    remove("settings_legacy_tmp.ini");
+    settings_clear(&unknown);
+    remove("settings_unknown_tmp.ini");
 }
 
 int main() {
@@ -95,6 +96,6 @@ int main() {
     RUN_TEST(testReadINI);
     RUN_TEST(testWriteINI);
     RUN_TEST(testControllerTouchpadDefaults);
-    RUN_TEST(testControllerTouchpadLegacyOffMode);
+    RUN_TEST(testControllerTouchpadUnknownMode);
     return UNITY_END();
 }

--- a/tests/app/test_settings.c
+++ b/tests/app/test_settings.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include "unity.h"
 #include "app_settings.h"
@@ -27,18 +28,62 @@ void testReadINI() {
     settings.ini_path = FIXTURES_PATH_PREFIX "settings_read.ini";
     TEST_ASSERT_TRUE(settings_read(&settings));
     settings.ini_path = ini_backup;
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, settings.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(125, settings.controller_touchpad_sensitivity);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_RIGHT, settings.controller_touchpad_press);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_MIDDLE, settings.controller_touchpad_secondary_click);
+    TEST_ASSERT_FALSE(settings.controller_touchpad_tap_to_click);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_two_finger_scroll);
+    TEST_ASSERT_FALSE(settings.controller_touchpad_invert_two_finger_scroll);
 }
 
 void testWriteINI() {
+    settings.controller_touchpad_mode = CONTROLLER_TOUCHPAD_MODE_NATIVE;
+    settings.controller_touchpad_sensitivity = 175;
+    settings.controller_touchpad_press = CONTROLLER_TOUCHPAD_PRESS_MIDDLE;
+    settings.controller_touchpad_secondary_click = CONTROLLER_TOUCHPAD_PRESS_LEFT;
+    settings.controller_touchpad_tap_to_click = false;
+    settings.controller_touchpad_two_finger_scroll = true;
+    settings.controller_touchpad_invert_two_finger_scroll = false;
+
     char *ini_backup = settings.ini_path;
     settings.ini_path = "settings_write_tmp.ini";
     TEST_ASSERT_TRUE(settings_save(&settings));
     settings.ini_path = ini_backup;
+
+    app_settings_t loaded;
+    settings_initialize(&loaded, settings.conf_dir);
+    char *loaded_ini_backup = loaded.ini_path;
+    loaded.ini_path = "settings_write_tmp.ini";
+    TEST_ASSERT_TRUE(settings_read(&loaded));
+    loaded.ini_path = loaded_ini_backup;
+
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_NATIVE, loaded.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(175, loaded.controller_touchpad_sensitivity);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_MIDDLE, loaded.controller_touchpad_press);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_LEFT, loaded.controller_touchpad_secondary_click);
+    TEST_ASSERT_FALSE(loaded.controller_touchpad_tap_to_click);
+    TEST_ASSERT_TRUE(loaded.controller_touchpad_two_finger_scroll);
+    TEST_ASSERT_FALSE(loaded.controller_touchpad_invert_two_finger_scroll);
+
+    settings_clear(&loaded);
+    remove("settings_write_tmp.ini");
+}
+
+void testControllerTouchpadDefaults() {
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_MODE_MOUSE, settings.controller_touchpad_mode);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_SENSITIVITY_DEFAULT, settings.controller_touchpad_sensitivity);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_LEFT, settings.controller_touchpad_press);
+    TEST_ASSERT_EQUAL_INT(CONTROLLER_TOUCHPAD_PRESS_RIGHT, settings.controller_touchpad_secondary_click);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_tap_to_click);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_two_finger_scroll);
+    TEST_ASSERT_TRUE(settings.controller_touchpad_invert_two_finger_scroll);
 }
 
 int main() {
     UNITY_BEGIN();
     RUN_TEST(testReadINI);
     RUN_TEST(testWriteINI);
+    RUN_TEST(testControllerTouchpadDefaults);
     return UNITY_END();
 }

--- a/tests/fixtures/settings_read.ini
+++ b/tests/fixtures/settings_read.ini
@@ -11,10 +11,10 @@ hevc = true
 hdr = true
 
 [input]
-controller_touchpad = mouse
-controller_touchpad_sensitivity = 125
-controller_touchpad_multitouch = false
-controller_touchpad_natural_scroll = false
+touchpad_mode = mouse
+touchpad_speed = 125
+touchpad_multitouch = false
+touchpad_natural_scroll = false
 
 [video]
 decoder = ffmpeg

--- a/tests/fixtures/settings_read.ini
+++ b/tests/fixtures/settings_read.ini
@@ -13,11 +13,8 @@ hdr = true
 [input]
 controller_touchpad = mouse
 controller_touchpad_sensitivity = 125
-controller_touchpad_press = right
-controller_touchpad_secondary_click = middle
-controller_touchpad_tap_to_click = false
-controller_touchpad_two_finger_scroll = true
-controller_touchpad_invert_two_finger_scroll = false
+controller_touchpad_multitouch = false
+controller_touchpad_natural_scroll = false
 
 [video]
 decoder = ffmpeg

--- a/tests/fixtures/settings_read.ini
+++ b/tests/fixtures/settings_read.ini
@@ -10,6 +10,15 @@ unknown = true
 hevc = true
 hdr = true
 
+[input]
+controller_touchpad = mouse
+controller_touchpad_sensitivity = 125
+controller_touchpad_press = right
+controller_touchpad_secondary_click = middle
+controller_touchpad_tap_to_click = false
+controller_touchpad_two_finger_scroll = true
+controller_touchpad_invert_two_finger_scroll = false
+
 [video]
 decoder = ffmpeg
 


### PR DESCRIPTION
# Improve controller touchpad, hotplug, and multi-controller support

## Summary

This Pull Request builds on `feat/grab-gamepad-touchpad` and adds configurable controller touchpad support together with several controller lifecycle, reconnect, multi-controller, and input-processing improvements.

The touchpad grab implementation from the base branch remains responsible for preventing webOS from intercepting controller touchpad gestures at the platform level. This PR focuses on how Moonlight handles controller touchpad input once those events reach SDL.

## Controller touchpad support

Adds configurable **Disabled**, **Mouse**, and **Native** touchpad modes.

### Mouse mode

Controller touchpads can be used as a mouse with support for:

* One-finger cursor movement
* Configurable pointer sensitivity
* Physical touchpad clicks
* Configurable lower-right secondary physical click
* Tap-to-click
* Tap-and-hold dragging
* Two-finger right click
* Two-finger horizontal and vertical scrolling
* Configurable scroll inversion
* High-resolution fractional pointer and scroll accumulation
* Per-controller touchpad gesture state

Two-finger scrolling uses the average/centroid movement of both contacts rather than summing their deltas, avoiding doubled sensitivity.

Once a two-finger scroll gesture begins, scroll mode remains locked until all fingers are released. This prevents the remaining finger from unexpectedly moving the mouse cursor while ending a scroll gesture.

Held mouse buttons are also released correctly when gestures are interrupted, fingers are lifted, physical touchpad presses occur, controllers disconnect, or the input state is reset.

### Native mode

Native mode forwards controller touch events using Moonlight's controller-touch protocol.

Touchpad capability detection uses SDL's reported controller touchpads where available rather than relying only on hardcoded controller types, and `LI_CCAP_TOUCHPAD` is advertised individually for applicable controllers.

## Controller lifecycle and reconnect handling

Improves controller arrival/removal handling during active streaming sessions.

Changes include:

* Synchronizing connected controllers when a stream starts
* Progressive active-controller masks when multiple controllers are already connected
* Correct controller removal notifications
* Resetting per-controller touchpad state on disconnect
* Keeping hotplug synchronization active even when normal gameplay input is temporarily blocked
* Explicit stream-input lifecycle tracking
* Avoiding unnecessary SDL haptic handles on modern SDL versions

## webOS controller reconnect discovery

Includes webOS-specific SDL fixes for controllers that disconnect and reconnect during the same session.

The SDL-webOS source revision is pinned so the required reconnect fixes can be applied directly.

The changes improve:

* evdev device re-enumeration
* stale joystick removal before re-adding a reconnecting device
* HIDAPI device reconciliation
* webOS polling-based joystick discovery

The SDL patch application is also idempotent so repeated CMake/CPack preinstall steps do not fail when the patch has already been applied.

## Multi-controller support

Expands Moonlight TV's local controller limit from 4 to the existing 16-controller capacity supported by Sunshine.

Controller arrival masks, touchpad state, and controller capabilities are handled independently for each controller.

## Controller input processing

Improves controller axis processing by:

* Precomputing the squared stick deadzone threshold
* Applying deadzone filtering only to the stick affected by the current axis event
* Making the deadzone helper const-correct
* Suppressing redundant controller packets when the effective post-deadzone state has not changed

This reduces unnecessary input traffic and helps avoid excessive event processing when several DInput or Bluetooth controllers are connected simultaneously.

## Relationship to `feat/grab-gamepad-touchpad`

This PR is intended to be used on top of `feat/grab-gamepad-touchpad`.

The base branch solves the webOS platform-level gesture problem by grabbing the controller touchpad's evdev node through `commons-gamepad-touchpad`.

Because of that, the previous implementation from #612 that attempted to correlate and suppress duplicate webOS touchscreen compatibility events is no longer included.

The following previous workarounds have been removed:

* Deferred touchscreen DOWN events
* Controller-touchpad/touchscreen compatibility-event correlation
* Touch-derived mouse-event suppression
* `controller_touchpad_webos_touchscreen`
* The webOS 25 `touchRemoteLaunchMode` notice
* The LGTVcli workaround

Actual touchscreen handling is left unchanged from the base branch.

## Testing

Tested with:

* Disabled, Mouse, and Native touchpad modes
* Cursor movement
* Physical touchpad clicks
* Tap-to-click
* Tap-and-hold dragging
* Two-finger right click
* Two-finger horizontal and vertical scrolling
* Scroll inversion
* Scroll pointer locking when lifting one finger
* Multiple simultaneous touchpad-capable controllers
* Multiple controllers connected before starting a stream
* Controller disconnect/reconnect during an active stream
* More than four controllers with Sunshine
* DInput and Bluetooth controllers
* Controller reset/disconnect while mouse buttons are held
* GitHub Actions webOS builds and packaging
