### PR TITLE
fix(pcmanager): allow forgetting hosts superseded by a new UUID

### DIFF
--- a/src/app/backend/pcmanager.h
+++ b/src/app/backend/pcmanager.h
@@ -62,6 +62,16 @@ bool pcmanager_select(pcmanager_t *manager, const uuidstr_t *uuid);
 
 bool pcmanager_forget(pcmanager_t *manager, const uuidstr_t *uuid);
 
+/**
+ * Whether a host is allowed to be removed from the known hosts list. This is the case when the host can't be
+ * reached, or when another known host has taken over its identity (same address and port, or same MAC). The
+ * latter happens when the host software is reinstalled, as that assigns the server a brand new UUID.
+ * @param manager
+ * @param uuid
+ * @return true if the host can be forgotten
+ */
+bool pcmanager_can_forget(pcmanager_t *manager, const uuidstr_t *uuid);
+
 void pcmanager_register_listener(pcmanager_t *manager, const pcmanager_listener_t *listener, void *userdata);
 
 void pcmanager_unregister_listener(pcmanager_t *manager, const pcmanager_listener_t *listener);

--- a/src/app/backend/pcmanager/pcmanager.c
+++ b/src/app/backend/pcmanager/pcmanager.c
@@ -6,6 +6,23 @@
 #include "app.h"
 #include "backend/pcmanager/worker/worker.h"
 #include "logging.h"
+#include "util/nullable.h"
+
+#include <strings.h>
+
+/**
+ * Whether two servers describe the same physical host. A reinstall of the host software keeps the address and
+ * the MAC, but assigns a new UUID, so neither can be compared against the UUID.
+ */
+static bool server_identity_equals(const SERVER_DATA *a, const SERVER_DATA *b) {
+    if (!str_null_or_empty(a->mac) && !str_null_or_empty(b->mac) && strcasecmp(a->mac, b->mac) == 0) {
+        return true;
+    }
+    if (str_null_or_empty(a->serverInfo.address) || str_null_or_empty(b->serverInfo.address)) {
+        return false;
+    }
+    return a->extPort == b->extPort && strcmp(a->serverInfo.address, b->serverInfo.address) == 0;
+}
 
 pcmanager_t *pcmanager_new(app_t *app, executor_t *executor) {
     pcmanager_t *manager = SDL_calloc(1, sizeof(pcmanager_t));
@@ -103,6 +120,42 @@ bool pcmanager_forget(pcmanager_t *manager, const uuidstr_t *uuid) {
     }
     pclist_remove(manager, uuid);
     return true;
+}
+
+bool pcmanager_can_forget(pcmanager_t *manager, const uuidstr_t *uuid) {
+    bool result = false;
+    pcmanager_lock(manager);
+    const pclist_t *node = pclist_find_by_uuid(manager, uuid);
+    if (node == NULL) {
+        goto unlock;
+    }
+    switch (node->state.code) {
+        case SERVER_STATE_NONE:
+        case SERVER_STATE_OFFLINE:
+        case SERVER_STATE_ERROR:
+            /* Never reached, or not reachable anymore */
+            result = true;
+            goto unlock;
+        default:
+            break;
+    }
+    if (node->server == NULL) {
+        result = true;
+        goto unlock;
+    }
+    for (const pclist_t *cur = manager->servers; cur != NULL; cur = cur->next) {
+        if (cur == node || cur->server == NULL) {
+            continue;
+        }
+        if (server_identity_equals(node->server, cur->server)) {
+            /* Another server, most likely a reinstall of the same host, uses this identity now */
+            result = true;
+            break;
+        }
+    }
+    unlock:
+    pcmanager_unlock(manager);
+    return result;
 }
 
 const pclist_t *pcmanager_node(pcmanager_t *manager, const uuidstr_t *uuid) {

--- a/src/app/ui/launcher/server.context_menu.c
+++ b/src/app/ui/launcher/server.context_menu.c
@@ -80,7 +80,7 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *parent) {
     lv_obj_add_flag(show_hidden_btn, LV_OBJ_FLAG_EVENT_BUBBLE);
     lv_obj_set_user_data(show_hidden_btn, show_hidden_apps);
 
-    if (node->state.code == SERVER_STATE_OFFLINE || node->state.code == SERVER_STATE_ERROR) {
+    if (pcmanager_can_forget(pcmanager, &controller->uuid)) {
         lv_obj_t *forget_btn = lv_list_add_btn(content, NULL, locstr("Forget"));
         lv_obj_add_flag(forget_btn, LV_OBJ_FLAG_EVENT_BUBBLE);
         lv_obj_set_user_data(forget_btn, forget_host);


### PR DESCRIPTION
Reinstalling the host software (GFE/Sunshine) assigns the server a brand new UUID. Both `hosts.ini` and the runtime server list are keyed strictly by that UUID — `known_hosts.c:87` writes it as the INI section name, and `upsert_perform` matches on it via `pclist_ll_compare_uuid` — so the same machine comes back as a *second* entry that shares the address and MAC of the old one. Nothing dedupes on load or on save, and the stale entry is reloaded forever.

Worse, it couldn't be removed by hand either. `Forget` was only drawn for `SERVER_STATE_OFFLINE` / `SERVER_STATE_ERROR`, but an entry loaded from `hosts.ini` starts at `SERVER_STATE_NONE` (`pclist.c:51`) and never gets refreshed, because discovery upserts the live host under the *new* UUID. The orphan sat at `NONE` with no way out.

## Change

New `pcmanager_can_forget()` decides whether the action is offered, and the context menu delegates to it. Forget is available when **either**:

1. the host can't be reached — `SERVER_STATE_NONE` (never contacted), `OFFLINE`, or `ERROR`; or
2. another known host has taken over its identity — same MAC (case-insensitive), or same `serverInfo.address` + `extPort`.

`server_identity_equals()` compares MAC and address rather than UUID, since the UUID is precisely what changed. The two conditions are OR'd, so a NIC swap or a host that doesn't report a MAC doesn't block the match, and empty strings are rejected on both sides so two hosts with a blank MAC don't collapse into each other.

## Note

Condition 2 is symmetric — once the new UUID is discovered, the new entry is forgettable too, since it also has a twin. That's deliberate: at that point either entry is a legitimate thing to remove, and the user is better placed than the app to say which. Happy to restrict it to non-`ONLINE` entries if you'd rather.

Not addressed here: automatically retiring the superseded entry in `upsert_perform`, and the `pclist_ll_compare_address` stub at `pclist.c:194-201` that unconditionally returns match (making `pclist_find_by_addr` return the first node regardless, so `lan_host_offline` marks the wrong server offline). Both are separate fixes.

## Testing

Built for webOS and installed on an LG UH6100 carrying a real duplicate — two `[MACHINE-NAME]` sections in `hosts.ini`, same MAC and `[HOST-IP]:47989`, different UUIDs. `Forget` now appears on the stale entry, where it previously did not. Note the list is only written on clean shutdown (`pcmanager_destroy`), so the app has to exit properly for a forget to stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVCybywSz3f8cuWx1qBtUw