### PR TITLE
feat(settings): option to keep performance stats pinned while streaming

### DIFF
--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -56,6 +56,7 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     config->sops = true;
     config->localaudio = false;
     config->fullscreen = true;
+    config->stats_overlay = false;
     if (!config->fullscreen) {
         config->window_state.w = 1280;
         config->window_state.h = 720;
@@ -92,6 +93,7 @@ bool settings_save(app_settings_t *config) {
     }
     ini_write_string(fp, "language", config->language);
     ini_write_bool(fp, "fullscreen", config->fullscreen);
+    ini_write_bool(fp, "stats_overlay", config->stats_overlay);
     ini_write_int(fp, "debug_level", config->debug_level);
 
     ini_write_section(fp, "streaming");
@@ -283,6 +285,8 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
 #else
         config->fullscreen = INI_IS_TRUE(value);
 #endif
+    } else if (INI_NAME_MATCH("stats_overlay")) {
+        config->stats_overlay = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("debug_level")) {
         set_int(&config->debug_level, value);
     } else if (INI_FULL_MATCH("window", "x")) {

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -37,6 +37,10 @@ typedef struct app_settings_t {
     bool sops;
     bool localaudio;
     bool fullscreen;
+    // Pin the performance stats over the stream from the moment it starts, so they can be read
+    // without the button combo that opens the overlay. Kept in sync with the overlay's own pin
+    // toggle, which writes back here.
+    bool stats_overlay;
     window_state_t window_state;
     int rotate;
     bool unsupported;

--- a/src/app/ui/settings/panes/basic.pane.c
+++ b/src/app/ui/settings/panes/basic.pane.c
@@ -140,6 +140,10 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     }
 #endif
 
+    pref_checkbox(view, locstr("Show performance stats while streaming"), &app_configuration->stats_overlay, false);
+    pref_desc_label(view, locstr("Keep latency, FPS and decoder stats pinned over the stream, without opening the "
+                                 "overlay first."), false);
+
 #ifdef FEATURE_I18N_LANGUAGE_SETTINGS
     lv_obj_t *lang_label = pref_title_label(view, "Language");
     if (strcmp(locstr("Language"), "Language") != 0) {

--- a/src/app/ui/streaming/streaming.controller.c
+++ b/src/app/ui/streaming/streaming.controller.c
@@ -128,6 +128,9 @@ static void constructor(lv_fragment_t *self, void *args) {
 
     const streaming_scene_arg_t *arg = (streaming_scene_arg_t *) args;
     controller->global = arg->global;
+    // Seed from the setting every session. Without this reset, a pin left over from the previous
+    // stream would keep streaming_stats_shown() true while the new panel sits hidden in the overlay.
+    overlay_pinned = controller->global->settings.stats_overlay;
     app_session_begin(arg->global, &arg->uuid, &arg->app);
 }
 
@@ -161,6 +164,14 @@ static bool on_event(lv_fragment_t *self, int code, void *userdata) {
             }
             lv_obj_add_flag(controller->overlay, LV_OBJ_FLAG_HIDDEN);
             lv_obj_add_flag(controller->hint, LV_OBJ_FLAG_HIDDEN);
+            if (controller->global->settings.stats_overlay) {
+                // Only once the stream is live. Doing this at view creation would lift the panel
+                // out of the hidden overlay while "Connecting..." is still up, showing an empty
+                // stats box for the whole handshake. Drive the existing pin rather than
+                // reparenting here, so the floating layout stays defined in pin_toggle alone.
+                lv_obj_add_state(controller->stats_pin, LV_STATE_CHECKED);
+                lv_event_send(controller->stats_pin, LV_EVENT_VALUE_CHANGED, NULL);
+            }
             break;
         }
         case USER_STREAM_CLOSE: {
@@ -342,6 +353,9 @@ static void pin_toggle(lv_event_t *e) {
     bool checked = lv_obj_has_state(lv_event_get_current_target(e), LV_STATE_CHECKED);
     bool pinned = toggle_view->parent != fragment->obj;
     overlay_pinned = checked;
+    // Same concept as the settings checkbox, so pinning or unpinning mid-stream is what the next
+    // session starts with. Persisted on exit like every other setting.
+    ((streaming_controller_t *) fragment)->global->settings.stats_overlay = checked;
     if (checked == pinned) {
         return;
     }

--- a/src/i18n/es-ES/messages.po
+++ b/src/i18n/es-ES/messages.po
@@ -343,6 +343,14 @@ msgstr "Interfaz a pantalla completa"
 msgid "Can't use windowed UI for this decoder"
 msgstr "No se puede usar la interfaz en ventana con este decodificador"
 
+#: src/app/ui/settings/panes/basic.pane.c:143
+msgid "Show performance stats while streaming"
+msgstr "Mostrar estadísticas de rendimiento durante la transmisión"
+
+#: src/app/ui/settings/panes/basic.pane.c:144
+msgid "Keep latency, FPS and decoder stats pinned over the stream, without opening the overlay first."
+msgstr "Mantener fijadas sobre la transmisión la latencia, los FPS y las estadísticas del decodificador, sin tener que abrir antes el menú superpuesto."
+
 #: src/app/ui/settings/panes/basic.pane.c:172
 #: src/app/ui/settings/panes/basic.pane.c:173
 msgid "Language"


### PR DESCRIPTION
Adds a **"Show performance stats while streaming"** checkbox to Basic settings. When it is on, the stats appear pinned over the video as soon as the stream is live — no button combo needed.

## Why

The stats panel is only reachable through the overlay, and the gamepad route to the overlay is **START + BACK + LB + RB**. Those buttons also reach the host while the combo is held, so with an Xbox controller on Windows the Game Bar opens and the game minimises — which loses the very stats you were trying to read. The keyboard combo (`Ctrl+Alt+Shift+S`) and the webOS remote RED/EXIT keys work fine, but there was no way to simply have the stats on, the way Steam Link's performance overlay does.

## How

- The setting **drives the overlay's existing pin control** rather than reparenting the panel itself: `USER_STREAM_OPEN` checks `stats_pin` and sends `LV_EVENT_VALUE_CHANGED`, so the floating layout and the pin's checked state stay defined in `pin_toggle` alone.
- `pin_toggle` writes back to the setting, so pinning or unpinning mid-stream is what the next session starts with. The two controls are one concept, reachable from two places, and it persists on exit like every other setting.

### Two things worth a reviewer's attention

**Why it applies on `USER_STREAM_OPEN` and not at view creation.** The stats panel carries no `HIDDEN` flag of its own — it is hidden purely by being a child of the hidden overlay. Reparenting it to `lv_layer_top()` any earlier lifts it out from under that and floats an empty stats box over the "Connecting…" dialog for the whole handshake. I had this wrong in the first draft and caught it on review. The event is posted from the session worker thread via `bus_pushevent`, so it is always drained after the synchronous fragment creation that registers the `pin_toggle` callback.

**A pre-existing bug fixed as a side effect.** The constructor reset `overlay_showing` but not `overlay_pinned`. A pin left over from an earlier stream therefore kept `streaming_stats_shown()` returning true, so `vdec_stat_submit` went on computing decoder latency and posting refreshes for a panel sitting hidden inside the new overlay. Seeding `overlay_pinned` from the setting each session fixes that.

## Verified statically

- `app_configuration` and `controller->global->settings` are the same object (`app.c:53`), so the checkbox and the streaming controller share state.
- `streaming.view.c` returns the overlay as the fragment root, so `pin_toggle`'s unpinned check against `fragment->obj` holds and the reparent actually happens — otherwise the feature would silently no-op.
- The `stats` user_data that `pin_toggle` dereferences is set during scene creation, before `on_view_created` runs.

## Translations

Spanish only, deliberately. You have pointed contributors at [Crowdin](https://crowdin.com/project/moonlight-tv) in #122, #428 and #430, so the other 15 locales are better served by going through there and its review flow than by unreviewed strings from someone who does not speak them.

`messages.pot` is untouched — you regenerate it and upload the template yourself ("I'll update pot file from time to time…", #430), and `xgettext` is not available on my machine. The `.po` entry stands on its own for `msgfmt` and will survive the next `msgmerge`, since the msgid exists in the source. Note the template is already behind main regardless: `Video bitrate - Unlimited` and `May exceed what this decoder can handle…` are missing from it too.

> [!IMPORTANT]
> **Not built, not tested.** No webOS toolchain or streaming host here, so the pinned layout has never been seen on a real screen. Worth a look at how it sits over the video at TV viewing distance before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
