### PR TITLE
fix(i18n): join multi-line entries and ship the es-ES and tr catalogs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ if (BUILD_TESTS)
     enable_testing()
 endif ()
 
-set(I18N_LOCALES "cs" "de" "fr" "it" "nl" "pl" "pt-BR" "ro" "ru" "ja" "zh-CN")
+set(I18N_LOCALES "cs" "de" "es-ES" "fr" "it" "nl" "pl" "pt-BR" "ro" "ru" "ja" "tr" "zh-CN")
 list(LENGTH I18N_LOCALES I18N_LOCALES_LEN)
 
 set(FEATURE_FORCE_FULLSCREEN OFF)

--- a/scripts/webos/po2json.awk
+++ b/scripts/webos/po2json.awk
@@ -1,22 +1,73 @@
 #!/usr/bin/awk -f
+#
+# Converts a gettext .po catalog into the flat JSON that webOS's resBundle
+# loads from resources/<lang>[/<region>]/cstrings.json.
+#
+# Entries with an empty msgstr are skipped, so an untranslated string falls
+# back to its msgid (English) at runtime instead of rendering blank.
+#
+# Continuation lines have to be joined. gettext splits long strings across
+# several quoted lines, but the C compiler concatenates the literals, so
+# locstr() looks up the joined string at runtime. Emitting only the first
+# line produces a key that can never match, silently dropping the
+# translation for exactly the longest messages.
+
+function unquote(line,   first) {
+    first = index(line, "\"")
+    return substr(line, first + 1, length(line) - first - 1)
+}
+
+function flush(   sep) {
+    # The header entry has an empty msgid and carries the .po metadata in its
+    # msgstr; skipping empty keys drops it along with untranslated entries.
+    if (key != "" && val != "") {
+        sep = (count > 0) ? ",\n" : ""
+        printf("%s  \"%s\": \"%s\"", sep, key, val)
+        count++
+    }
+    key = ""
+    val = ""
+    state = ""
+}
 
 BEGIN {
-    ENTRY_COUNT = 0
+    count = 0
+    key = ""
+    val = ""
+    state = ""
     print ("{")
 }
 
-match($0, /^msgid "(.+)"$/, group) {
-    ENTRY_KEY = group[1]
+# Tolerate CRLF checkouts, which would otherwise leave a stray carriage
+# return inside the emitted JSON string.
+{ sub(/\r$/, "") }
+
+/^msgid[ \t]+"/ {
+    flush()
+    key = unquote($0)
+    state = "id"
+    next
 }
 
-match($0, /^msgstr "(.+)"$/, group) {
-    if (ENTRY_COUNT > 0) {
-        printf (",\n")
-    }
-    printf ("  \"%s\": \"%s\"", ENTRY_KEY, group[1])
-    ENTRY_COUNT++
+/^msgstr[ \t]+"/ {
+    val = unquote($0)
+    state = "str"
+    next
 }
+
+/^"/ {
+    if (state == "id") {
+        key = key unquote($0)
+    } else if (state == "str") {
+        val = val unquote($0)
+    }
+    next
+}
+
+# Anything else - blank line, comment, obsolete entry - ends the current one.
+{ flush() }
 
 END {
+    flush()
     print ("\n}")
 }

--- a/src/app/platform/common/i18n_common.c
+++ b/src/app/platform/common/i18n_common.c
@@ -7,7 +7,9 @@ static const i18n_entry_t i18n_locales[] = {
         {"en-US", "English"},
         {"cs", "Čeština"},
         {"de", "Deutsch"},
-        {"es", "Español"},
+        // Must match the src/i18n directory name: the dropdown stores this code and
+        // i18n_setlocale() turns it into the resources/<lang>/<region> lookup path.
+        {"es-ES", "Español"},
         {"fr", "Français"},
         {"it", "Italiano"},
 #if DEBUG
@@ -19,6 +21,7 @@ static const i18n_entry_t i18n_locales[] = {
         {"pt-BR", "Português (Brasil)"},
         {"ro", "Română"},
         {"ru", "Русский"},
+        {"tr", "Türkçe"},
         {"zh-CN", "简体中文",
 #if OS_WINDOWS
                 .font =        "Microsoft YaHei"


### PR DESCRIPTION
Three related defects in how translation catalogs reach a webOS device. Found while investigating why Spanish never appears; the first one turned out to affect every language.

## 1. `po2json.awk` truncated every multi-line entry

This is the one worth your attention — it degrades **all 11 shipped locales**, including `fr` and `zh-CN` which are effectively complete.

gettext wraps long strings across continuation lines, but the C compiler concatenates the literals, so `locstr()` looks up the joined string at runtime. The converter matched one line at a time, so it emitted a key that stopped at the first line. Straight from an `.ipk` built by CI:

```json
"Press \"Retry\" to load again.\n\n": "Appuyez sur \"Réessayer\" pour recharger.\n\n",
```

The runtime key is `Press \"Retry\" to load again.\n\nRestart your computer if error persists.` — so that entry can never match, and the message silently falls back to English. It hits exactly the five long error dialogs: retry, Wake-on-LAN, no valid decoder, unwritable settings directory, and the host info block.

You can see it on a device today: set the TV to French and open a host that's offline — menus are French, that dialog is English.

The rewrite accumulates continuation lines and flushes on any other line. It also drops the gawk-only three-argument `match()` in favour of `substr()`/`index()`, so the script no longer depends on which awk `find_program(AWK NAMES gawk awk)` picks, and strips a trailing CR so a CRLF checkout can't leak one into the JSON.

**Verified by running it**, old vs new against all 11 shipped catalogs:

- Identical key counts in every locale.
- The only differing lines are the five multi-line entries, now carrying their full text.
- Output parses as JSON (126 keys for `fr`).
- Untranslated entries are still skipped — `ro` (62/126 translated) still emits exactly 62, so the rest keeps falling back to English rather than rendering blank.

## 2. `es-ES` was translated but never shipped

`I18N_LOCALES` governs `.mo` compilation, the webOS `cstrings.json` generation *and* the language dropdown. `es-ES` was absent, so despite being 126/126 the catalog was never packaged. I confirmed this by extracting an `.ipk` built by this repo's CI — 11 locale directories, no Spanish. A Spanish TV therefore gets English under *System Language* (`resources/es/ES/cstrings.json` doesn't exist), and Spanish isn't offered in the dropdown either.

## 3. The `es` entry code didn't match its catalog directory

`i18n_locales[]` listed `{"es", …}` while the directory is `es-ES`. Every other locale matches exactly (`pt-BR`, `zh-CN`). Since the dropdown stores this code and `i18n_setlocale()` turns it into the `resources/<lang>/<region>` path, adding `es-ES` to `I18N_LOCALES` *alone* would have fixed System Language while leaving an explicit Spanish selection looking up `resources/es/` — a path that wouldn't exist. Both had to change together.

## Also packaged: `tr`

At 70/126 Turkish is more complete than `ro` (62/126), which already ships, so the omission looked accidental. It needed an `i18n_locales[]` entry to show up in the dropdown.

`ko`, `uk` and `zh-TW` stay out: all three are 0/126, so shipping them would only add empty files.

> [!NOTE]
> **Not built on a device.** The awk change is verified by actually running it against every catalog. The packaging change needs a webOS build to confirm the `.ipk` layout, and a Spanish TV to confirm *System Language* resolves — happy to test that side once CI produces an artifact.

Related: #616 adds a setting whose Spanish string is in the catalog this PR finally ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
