### PR TITLE
fix(input): don't repeat keypress after main loop stall

### DIFF
--- a/src/app/lvgl/input/lv_drv_sdl_key.c
+++ b/src/app/lvgl/input/lv_drv_sdl_key.c
@@ -41,11 +41,33 @@ void lv_sdl_key_input_release_key(lv_indev_t *indev) {
     state->state = LV_INDEV_STATE_RELEASED;
 }
 
+/* A gap between two reads longer than this means the main loop stalled rather
+ * than the user holding a key. Well above a normal frame, well below LVGL's
+ * 400ms long_press_time, so a genuine hold is never mistaken for a stall. */
+#define KEY_STALL_THRESHOLD_MS 100
+
 static void sdl_input_read(lv_indev_drv_t *drv, lv_indev_data_t *data) {
     app_ui_input_t *input = drv->user_data;
     app_t *app = input->ui->app;
     lv_drv_sdl_key_t *state = (lv_drv_sdl_key_t *) drv;
     SDL_Event e;
+
+    /* A key held across a main-loop stall must not turn into a repeat. LVGL derives
+     * long press purely from wall-clock time, so a stall longer than long_press_time
+     * makes a tap indistinguishable from a hold. This must run before the stalled
+     * read is processed: indev_keypad_proc() evaluates long press immediately after
+     * this callback returns, within the same lv_timer_handler pass.
+     *
+     * Parking the press with lv_indev_wait_release() rather than merely discounting
+     * the stalled time is deliberate: the UI is frozen and unresponsive during the
+     * stall, so users keep holding, and any duration-based compensation eventually
+     * loses to a long enough hold. LVGL clears the flag and resets its press state
+     * on release, so the next deliberate press behaves normally. */
+    if (state->last_read_tick != 0 && state->state == LV_INDEV_STATE_PRESSED &&
+        input->key.indev != NULL && lv_tick_elaps(state->last_read_tick) >= KEY_STALL_THRESHOLD_MS) {
+        lv_indev_wait_release(input->key.indev);
+    }
+    state->last_read_tick = lv_tick_get();
     if (state->text_remain > 0) {
         if (state->state == LV_INDEV_STATE_PRESSED) {
             state->state = LV_INDEV_STATE_RELEASED;

--- a/src/app/lvgl/input/lv_drv_sdl_key.h
+++ b/src/app/lvgl/input/lv_drv_sdl_key.h
@@ -14,6 +14,7 @@ typedef struct lv_drv_sdl_key_t {
     uint8_t text_remain;
     uint32_t text_next;
     bool changed;
+    uint32_t last_read_tick;
 } lv_drv_sdl_key_t;
 
 int lv_sdl_init_key_input(lv_drv_sdl_key_t *drv, app_ui_input_t *input);


### PR DESCRIPTION
## Problem

LVGL derives long press and key repeat purely from wall-clock time since the press was registered. When a single main loop iteration blocks for longer than `long_press_time` (400ms), a plain tap becomes indistinguishable from a hold — `indev_keypad_proc()` sees the key still down with ~500ms elapsed, sets `long_pr_sent`, and the repeat that follows fires a second navigation step.

In the settings screen this makes nav entries unreachable. `on_entry_focus` builds a pane synchronously, so merely *passing over* a heavy entry stalls the loop, and the phantom repeat carries focus past it to the next one.

Reproduced on an LG UH6100 (webOS 3.4.0). Trace from an instrumented build, one physical D-pad press:

```
KEYEV pad btn=12 DOWN   tick=54814
NAVKEY focus_next       tick=54814     <- Host -> Input
PANETIME Input Settings: 488 ms
NAVKEY focus_next       tick=55414     <- second move, no new event
PANETIME Audio Settings: 13 ms
KEYEV pad btn=12 UP     tick=55429
```

One press, two `focus_next` calls, no second input event. The second move lands 600ms after the press — 400ms `long_press_time` plus one `long_press_repeat_time`.

Pane build times on that set, for context on why this pane and not others:

| Pane | Build time |
|---|---|
| Basic | 13-17 ms |
| Audio | 13-17 ms |
| Host | 41-47 ms |
| Video | 85 ms |
| Input | 490-496 ms |

## Fix

Track when the keypad driver was last polled and treat a gap larger than 100ms as a stall rather than as time the user spent holding a key. When a key is down across such a gap, park the press with `lv_indev_wait_release()`, so it performs its one action and is then ignored until physically released. LVGL clears the flag and resets `pr_timestamp` / `long_pr_sent` on release, so the next deliberate press behaves normally.

Two details that matter:

- **Placement.** This runs at the top of the read callback, before the stalled read is processed. `indev_keypad_proc()` evaluates long press immediately after the callback returns, within the same `lv_timer_handler` pass, so compensating anywhere later (e.g. after `lv_task_handler()` in the main loop) is too late.
- **Parking rather than discounting.** Shifting `pr_timestamp` forward by the stall duration was tried first and is insufficient: the UI is frozen and gives no feedback during a stall, so users keep holding, and a long enough hold still accumulates 400ms of real time. Parking is duration-independent.

The threshold sits well above a normal frame and well below `long_press_time`, so a genuine hold is never mistaken for a stall. The guard uses the driver's own state and `lv_indev_wait_release()` is public API, so no LVGL internals are touched.

## Verification

Same set, after the fix — every `DOWN` yields exactly one `focus_next`:

```
KEYEV pad btn=12 DOWN   tick=15697
NAVKEY focus_next       tick=15698
PANETIME Input Settings: 496 ms
KEYEV pad btn=12 UP     tick=16299
```

Held 602ms, well past `long_press_time`, and no repeat fired. Pane build times are unchanged at ~493ms, so this is an input-layer fix rather than an accidental speedup.

## Notes

- The underlying cost is untouched. Building an entire pane just to pass over a nav entry is a design flaw worth addressing separately; this only stops it from stealing keypresses.
- Behaviour change: holding to auto-scroll through a list that hits an unrelated >100ms hitch will now stop repeating until the key is released, instead of resuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVCybywSz3f8cuWx1qBtUw