### PR TITLE
feat(launcher): optionally keep retrying the connection after Wake-on-LAN

### DIFF
--- a/src/app/app_settings.c
+++ b/src/app/app_settings.c
@@ -62,6 +62,7 @@ void settings_initialize(app_settings_t *config, char *conf_dir) {
     set_string(&config->decoder, "auto");
     config->audio_device = NULL;
     config->sops = true;
+    config->wol_keep_retrying = false;
     config->localaudio = false;
     config->fullscreen = true;
     if (!config->fullscreen) {
@@ -116,6 +117,7 @@ bool settings_save(app_settings_t *config) {
 
     ini_write_section(fp, "host");
     ini_write_bool(fp, "sops", config->sops);
+    ini_write_bool(fp, "wol_keep_retrying", config->wol_keep_retrying);
     ini_write_bool(fp, "localaudio", config->localaudio);
     ini_write_bool(fp, "quitappafter", config->quitappafter);
     ini_write_bool(fp, "viewonly", config->viewonly);
@@ -283,6 +285,8 @@ static int settings_parse(app_settings_t *config, const char *section, const cha
         config->stream.audioConfiguration = parse_audio_config(value);
     } else if (INI_NAME_MATCH("sops")) {
         config->sops = INI_IS_TRUE(value);
+    } else if (INI_NAME_MATCH("wol_keep_retrying")) {
+        config->wol_keep_retrying = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("localaudio")) {
         config->localaudio = INI_IS_TRUE(value);
     } else if (INI_NAME_MATCH("quitappafter")) {

--- a/src/app/app_settings.h
+++ b/src/app/app_settings.h
@@ -44,6 +44,9 @@ typedef struct app_settings_t {
     char *audio_device;
     char *language;
     bool sops;
+    // After a Wake-on-LAN packet, keep polling the host until it answers instead of leaving the
+    // user to press Retry. See WAKE_RETRY_TIMEOUT_MS in apps.controller.c for how long.
+    bool wol_keep_retrying;
     bool localaudio;
     bool fullscreen;
     window_state_t window_state;

--- a/src/app/ui/launcher/apps.controller.c
+++ b/src/app/ui/launcher/apps.controller.c
@@ -90,6 +90,14 @@ static void action_cb_host_reload(apps_fragment_t *controller, lv_obj_t *buttons
 
 static void action_cb_pair(apps_fragment_t *controller, lv_obj_t *buttons, uint16_t index);
 
+static void action_cb_wake_cancel(apps_fragment_t *controller, lv_obj_t *buttons, uint16_t index);
+
+static void wake_retry_start(apps_fragment_t *controller);
+
+static void wake_retry_stop(apps_fragment_t *controller);
+
+static void wake_retry_tick(lv_timer_t *timer);
+
 static void update_grid_config(apps_fragment_t *controller);
 
 static void open_context_menu(apps_fragment_t *fragment, appitem_viewholder_t *holder);
@@ -143,6 +151,11 @@ const lv_fragment_class_t apps_controller_class = {
         .instance_size = sizeof(apps_fragment_t),
 };
 
+// Wake-on-LAN only starts the machine; the streaming service takes a while longer to listen.
+// Poll for up to two minutes so a cold boot completes without the user pressing Retry.
+#define WAKE_RETRY_INTERVAL_MS 3000
+#define WAKE_RETRY_TIMEOUT_MS 120000
+
 static const char *action_labels_offline[] = {translatable("Wake"), translatable("Retry"), ""};
 static const action_cb_t action_callbacks_offline[] = {action_cb_wol, action_cb_host_reload};
 static const char *action_labels_error[] = {translatable("Retry"), ""};
@@ -150,6 +163,8 @@ static const action_cb_t action_callbacks_error[] = {action_cb_host_reload};
 static const char *actions_unpaired[] = {translatable("Pair"), ""};
 static const action_cb_t action_callbacks_unpaired[] = {action_cb_pair};
 static const char *actions_apps_none[] = {""};
+static const char *action_labels_waking[] = {translatable("Cancel"), ""};
+static const action_cb_t action_callbacks_waking[] = {action_cb_wake_cancel};
 
 static void apps_controller_ctor(lv_fragment_t *self, void *args) {
     apps_fragment_t *controller = (apps_fragment_t *) self;
@@ -167,6 +182,8 @@ static void apps_controller_ctor(lv_fragment_t *self, void *args) {
 
 static void apps_controller_dtor(lv_fragment_t *self) {
     apps_fragment_t *fragment = (apps_fragment_t *) self;
+    // The timer outlives the object tree, so it has to go before the fragment memory does.
+    wake_retry_stop(fragment);
     appitem_style_deinit(&fragment->appitem_style);
     apploader_destroy(fragment->apploader);
     if (fragment->apploader_apps != NULL) {
@@ -359,7 +376,15 @@ static void send_wol_cb(int result, const char *error, const uuidstr_t *uuid, vo
     lv_btnmatrix_clear_btn_ctrl_all(controller->actions, LV_BTNMATRIX_CTRL_DISABLED);
     const SERVER_STATE *state = pcmanager_state(pcmanager, &controller->uuid);
     if (state == NULL) { return; }
-    if (state->code & SERVER_STATE_ONLINE || result != GS_OK) { return; }
+    if (state->code & SERVER_STATE_ONLINE) { return; }
+    if (app_configuration->wol_keep_retrying) {
+        // The result is deliberately ignored here. worker_wol reports its last failed probe, which
+        // after a cold boot is usually just its own short window expiring, and ECONNREFUSED means
+        // the machine is up but the streaming service is not listening yet. Both mean keep waiting.
+        wake_retry_start(controller);
+        return;
+    }
+    if (result != GS_OK) { return; }
     pcmanager_request_update(pcmanager, &controller->uuid, host_info_cb, NULL);
 }
 
@@ -431,6 +456,18 @@ static void update_view_state(apps_fragment_t *controller) {
             break;
         }
         case SERVER_STATE_OFFLINE: {
+            if (controller->wake_retry_timer != NULL) {
+                show_error(controller, locstr("Waking computer"),
+                           locstr("Waiting for the computer to finish starting up. This can take a minute."),
+                           NULL);
+                set_actions(controller, action_labels_waking, action_callbacks_waking);
+                // _all rather than index 0: lv_btnmatrix_set_map only zeroes the control bits when the
+                // button count changes, so a same-map re-render must not inherit a stale DISABLED.
+                lv_btnmatrix_clear_btn_ctrl_all(controller->actions, LV_BTNMATRIX_CTRL_DISABLED);
+                // Deliberately no focus grab here: on_host_updated() re-renders this view after every
+                // poll, and stealing focus every few seconds would fight the user for two minutes.
+                break;
+            }
             // server has error
             show_error(controller, locstr("Offline"),
                        locstr("Press \"Wake\" to send Wake-on-LAN packet to turn the computer on if it supports this feature, "
@@ -703,6 +740,52 @@ static void action_cb_pair(apps_fragment_t *controller, lv_obj_t *buttons, uint1
     LV_UNUSED(buttons);
     LV_UNUSED(index);
     pair_dialog_open(&controller->uuid);
+}
+
+static void action_cb_wake_cancel(apps_fragment_t *controller, lv_obj_t *buttons, uint16_t index) {
+    LV_UNUSED(buttons);
+    LV_UNUSED(index);
+    wake_retry_stop(controller);
+    update_view_state(controller);
+}
+
+static void wake_retry_start(apps_fragment_t *controller) {
+    if (controller->wake_retry_timer != NULL) {
+        return;
+    }
+    controller->wake_retry_deadline = SDL_GetTicks() + WAKE_RETRY_TIMEOUT_MS;
+    controller->wake_retry_timer = lv_timer_create(wake_retry_tick, WAKE_RETRY_INTERVAL_MS, controller);
+    update_view_state(controller);
+}
+
+static void wake_retry_stop(apps_fragment_t *controller) {
+    if (controller->wake_retry_timer == NULL) {
+        return;
+    }
+    lv_timer_del(controller->wake_retry_timer);
+    controller->wake_retry_timer = NULL;
+    controller->wake_retry_deadline = 0;
+}
+
+static void wake_retry_tick(lv_timer_t *timer) {
+    apps_fragment_t *controller = timer->user_data;
+    // The fragment may have been swapped out without its destructor running yet.
+    if (controller != current_instance || !controller->base.managed->obj_created) {
+        wake_retry_stop(controller);
+        return;
+    }
+    const SERVER_STATE *state = pcmanager_state(pcmanager, &controller->uuid);
+    if (state != NULL && (state->code & SERVER_STATE_ONLINE)) {
+        // on_host_updated() takes it from here and loads the app list.
+        wake_retry_stop(controller);
+        return;
+    }
+    if (SDL_TICKS_PASSED(SDL_GetTicks(), controller->wake_retry_deadline)) {
+        wake_retry_stop(controller);
+        update_view_state(controller);
+        return;
+    }
+    pcmanager_request_update(pcmanager, &controller->uuid, NULL, NULL);
 }
 
 static void open_context_menu(apps_fragment_t *fragment, appitem_viewholder_t *holder) {

--- a/src/app/ui/launcher/apps.controller.h
+++ b/src/app/ui/launcher/apps.controller.h
@@ -40,6 +40,11 @@ typedef struct {
 
     lv_obj_t *quit_progress;
 
+    // Set while auto-retrying after Wake-on-LAN: the timer polls the host until it answers or
+    // wake_retry_deadline passes. Both are cleared together by wake_retry_stop().
+    lv_timer_t *wake_retry_timer;
+    uint32_t wake_retry_deadline;
+
     appitem_styles_t appitem_style;
     int col_count;
     lv_coord_t col_width, col_height;

--- a/src/app/ui/settings/panes/host.pane.c
+++ b/src/app/ui/settings/panes/host.pane.c
@@ -27,6 +27,10 @@ static lv_obj_t *create_obj(lv_fragment_t *self, lv_obj_t *container) {
     pref_desc_label(view, locstr("Change in-game settings to optimize for streaming. Resolution will be "
                                  "limited to 720p, 1080p or 4K. Framerate will be also limited to 30/60 FPS."),
                     false);
+    pref_checkbox(view, locstr("Keep trying to connect after Wake-on-LAN"), &app_configuration->wol_keep_retrying,
+                  false);
+    pref_desc_label(view, locstr("After sending the wake packet, keep retrying until the computer answers, "
+                                 "for up to two minutes."), false);
     pref_checkbox(view, locstr("Mute computer while streaming"), &app_configuration->localaudio, true);
     return view;
 }

--- a/src/i18n/es-ES/messages.po
+++ b/src/i18n/es-ES/messages.po
@@ -148,6 +148,14 @@ msgstr "Error del host"
 msgid "Offline"
 msgstr "Sin conexión"
 
+#: src/app/ui/launcher/apps.controller.c:435
+msgid "Waking computer"
+msgstr "Encendiendo el ordenador"
+
+#: src/app/ui/launcher/apps.controller.c:436
+msgid "Waiting for the computer to finish starting up. This can take a minute."
+msgstr "Esperando a que el ordenador termine de arrancar. Puede tardar un minuto."
+
 #: src/app/ui/launcher/apps.controller.c:427
 msgid "Press \"Wake\" to send Wake-on-LAN packet to turn the computer on if it supports this feature, press \"Retry\" to connect again.\n\n"
 "Try restart your computer if these doesn't work."
@@ -372,6 +380,14 @@ msgstr "Cambie los ajustes del juego para optimizar la transmisión. La resoluci
 #: src/app/ui/settings/panes/host.pane.c:30
 msgid "Mute computer while streaming"
 msgstr "Silenciar el ordenador durante la transmisión"
+
+#: src/app/ui/settings/panes/host.pane.c:30
+msgid "Keep trying to connect after Wake-on-LAN"
+msgstr "Seguir intentando conectar tras Wake-on-LAN"
+
+#: src/app/ui/settings/panes/host.pane.c:32
+msgid "After sending the wake packet, keep retrying until the computer answers, for up to two minutes."
+msgstr "Tras enviar el paquete de encendido, seguir reintentando hasta que el ordenador responda, durante un máximo de dos minutos."
 
 #: src/app/ui/settings/panes/input.pane.c:46
 msgid "View-only mode"


### PR DESCRIPTION
Waking a PC from the launcher leaves you watching the Offline screen and pressing **Retry** until the machine finally answers. This adds a Host setting — **"Keep trying to connect after Wake-on-LAN"** — that makes the app keep trying on its own, so the flow is closer to a console: press Wake, put the remote down.

**Off by default.** The Wake button behaves exactly as before unless the setting is on; the diff removes a single line from the existing code path.

## Why a setting rather than a second button

I tried a third "Wake and wait" button first. Two things argued against it: three buttons crowd the offline view, whose button matrix is fixed to a single line of text height (so it can't wrap to two rows without touching code shared by every error view), and this is a preference you set once rather than a choice you want to make at every boot.

## What was already there

Most of the machinery exists. `worker_wol` broadcasts the magic packet and then polls `gs_get_status` every 3 seconds, and `on_host_updated` already loads the app list as soon as the host reports available. Two things stopped it short:

- **`worker_wol` gives up after 15 seconds.** A cold boot into Windows with GFE or Sunshine listening usually takes considerably longer, so that window nearly always expired first.
- **`send_wol_cb` then returned without scheduling anything**, treating a non-`GS_OK` result as failure. `worker_wol` also breaks out of its loop on `ECONNREFUSED` — the machine is up but the streaming service isn't listening yet, precisely when waiting pays off — and reports that as a failure too.

With the setting on, the result is deliberately ignored for that reason. The default path still checks it exactly as before.

## How

Rather than stretching `worker_wol`'s timeout — which would tie up a worker thread for minutes with no way to cancel and no feedback — the retry lives in the controller: an `lv_timer` polls the host every 3 seconds for up to two minutes. While it runs the view shows *"Waking computer"* with a single **Cancel** button, so the wait is visible and interruptible. Success needs no special handling: `on_host_updated` notices the host became available and loads the apps.

## Details worth a reviewer's attention

- The waking branch of `update_view_state` **deliberately does not grab focus**. `on_host_updated` re-renders after every poll, so focusing there would yank the selection back every 3 seconds for two minutes.
- That branch clears `DISABLED` with the `_all` variant rather than index 0. `lv_btnmatrix_set_map` only zeroes the control bits when the button *count* changes (*"Do not allocate memory for the same amount of buttons"*), so a same-map re-render could otherwise inherit a stale `DISABLED` and leave Cancel dead.
- `lv_timer_del()` is called from inside the timer's own callback. LVGL supports this — `lv_timer_del` sets `timer_deleted` and `lv_timer_handler` restarts its iteration (*"The timer might be deleted by itself as well"*, `lv_timer.c:319` in the pinned fork). Verified against that source rather than assumed.
- The timer is stopped in `apps_controller_dtor`, since it would otherwise outlive the fragment memory it points at.
- `pcmanager_request_update` is called with a NULL callback; `request.c` guards with `if (ctx->callback)`.
- **This is the first `lv_timer_create` in the codebase** — standard LVGL, but no precedent here, so worth a look if you'd rather it used `SDL_AddTimer` + `app_bus_post` like `session_virt_mouse.c`.

## Translations

Spanish only; the rest go through [Crowdin](https://crowdin.com/project/moonlight-tv) as usual. "Cancel" already existed. `messages.pot` untouched — you regenerate it yourself.

> [!IMPORTANT]
> **Not built, not tested.** No webOS toolchain here, and the behaviour that matters — a genuinely powered-off PC coming up inside the two-minute window — can only be checked against real hardware. The two-minute timeout and 3-second interval are judgement calls; happy to change either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
