### PR TITLE
ci(release): download only the amd64 webOS tooling debs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: "webosbrew/ares-cli-rs"
           latest: true
-          fileName: "ares-package_*.deb"
+          fileName: "ares-package_*_amd64.deb"
           out-file-path: "temp"
 
       - name: Download Manifest Generator
@@ -32,7 +32,7 @@ jobs:
         with:
           repository: "webosbrew/dev-toolbox-cli"
           latest: true
-          fileName: "webosbrew-toolbox-gen-manifest_*.deb"
+          fileName: "webosbrew-toolbox-gen-manifest_*_amd64.deb"
           out-file-path: "temp"
 
       - name: Update Packages
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     strategy:
+      fail-fast: false
       matrix:
         arch: [ armhf, arm64 ]
 


### PR DESCRIPTION
The webOS release job globbed `ares-package_*.deb` and
`webosbrew-toolbox-gen-manifest_*.deb`. Both upstream projects now ship an
arm64 deb alongside the amd64 one, so the downloader grabbed both and
`apt-get install ./temp/*.deb` tried to install the arm64 packages on an
amd64 runner, failing on unmet `libc6:arm64` dependencies and package
conflicts. Pin the patterns to `_amd64.deb`, matching what build-webos.yml
already does.

Also stop the Raspberry Pi matrix from cancelling itself: the arm64 job
fails to link against the bookworm sysroot, which took the armhf job down
with it and left no Pi package published at all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013vrHNN7R8FCziQ7hHXSBdh